### PR TITLE
Add a special tag to remote instrumenter

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -113,7 +113,9 @@ Resources:
           DD_JAVA_LAYER_VERSION: !Ref DdJavaLayerVersion
           DD_DOTNET_LAYER_VERSION: !Ref DdDotnetLayerVersion
           DD_RUBY_LAYER_VERSION: !Ref DdRubyLayerVersion
-
+      Tags:
+        - Key: "dd_serverless_service"
+          Value: "remote_instrumenter"
       Code:
         ZipFile: |
           INJECT_ENTRY_FUNCTION_CODE_PLACEHOLDER


### PR DESCRIPTION
Since customers can rename the Remote Instrumenter function name, for our FrontEnd to know which function is the Remote Instrumenter, we're adding `dd_serverless_service:remote_instrumenter` tag to the Remote Instrumenter.

The PR is tested as screenshot shows.

<img width="577" alt="image" src="https://github.com/DataDog/Serverless-Remote-Instrumentation/assets/47579703/3ededb32-401a-4b75-a081-6b5f8289fd8d">
