### PR TITLE
Limit instrumenter role when tagging

### DIFF
--- a/self-monitoring-app/template.yaml
+++ b/self-monitoring-app/template.yaml
@@ -83,7 +83,7 @@ Resources:
       - LambdaFunctionWithSpecifiedTags
       - LambdaFunctionWithoutSpecifiedTags
     Properties:
-      TemplateURL: https://datadog-cloudformation-template-serverless-sandbox.s3.amazonaws.com/aws/remote-instrument-dev/latest.yaml
+      TemplateURL: https://datadog-cloudformation-template-serverless-sandbox.s3.amazonaws.com/aws/remote-instrument-dev/0.7.5.yaml
       Parameters:
         DdApiKey: !Ref DdApiKey
         DdSite: !Ref DdSite

--- a/template.yaml
+++ b/template.yaml
@@ -147,6 +147,9 @@ Resources:
               - tag:TagResources
               - tag:UntagResources
             Resource: '*'
+            Condition:
+              ArnEquals:
+                lambda:SourceFunctionArn: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${InstrumenterFunctionName}
 #            Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*  # doesn't work
 #            Resource: 'arn:aws:lambda:*'  # doesn't work
 


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-4321

1. Limit instrumenter IAM role to mutate only by requests coming from the instrumenter.
2. Pin self-monitoring app to a specific instrumenter stack version to avoid being affected by dev testing changes published to latest yaml file.

## Note
> If you want to implement least privileges on your lambda function you can achieve this through specifying the resource for the "lambda:TagResource" permission [2]

This suggestion does not work. We still get the the following error`2024-04-09T18:40:14.611Z	796ea38b-dfa6-478e-b59d-bddbd36b86e5	ERROR	[dd.trace_id=8436779288372044732 dd.span_id=4576486132704298181] error: AccessDeniedException: User: arn:aws:sts::425362996713:assumed-role/datadog-remote-instrument-LambdaExecutionRole-ut6XHiiq9Hc0/datadog-remote-instrumenter is not authorized to perform: tag:TagResources because no identity-based policy allows the tag:TagResources action when tagging resources`