### PR TITLE
Uninstrument ALL remote-instrumented functions by using `*` in DenyList

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -237,12 +237,16 @@ async function instrumentByEvent(event, config) {
     // special handling for specific event
     // event.detail.requestParameters.functionName for update function event can be ARN or function name
     if (event.hasOwnProperty("detail") && event.detail.hasOwnProperty("eventName") && event.detail.eventName === "UpdateFunctionConfiguration20150331v2") {
-        let actuallyFunctionArn = event.detail.requestParameters.functionName;
+        let actuallyFunctionArn = event.detail.requestParameters.functionName;  // functionName here is actually function ARN
         let arnParts = actuallyFunctionArn.split(':');
         functionName = arnParts[arnParts.length - 1];
         console.log(`actuallyFunctionArn: ${actuallyFunctionArn}  arnParts: ${JSON.stringify(arnParts)}  functionName:${functionName}`);
     }
 
+    if (config.DenyList === '*') {
+        logger.logInstrumentStatus(INSTRUMENT_STATUS, SKIPPED, functionName)
+        return;
+    }
     logger.debugStatus(LAMBDA_EVENT, PROCESSING, functionName, "Lambda management event is received and starting instrumentation")
 
     // filter out functions that are on the DenyList

--- a/template.yaml
+++ b/template.yaml
@@ -72,6 +72,7 @@ Resources:
       - arm64
       Runtime: nodejs20.x
       ReservedConcurrentExecutions: 1
+      #      CodeSigningConfigArn: arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc
       Timeout: 840
       MemorySize: 512
       Role: !GetAtt LambdaExecutionRole.Arn


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-4609

- Uninstrument ALL remote-instrumented functions by using * in DenyList
- Add `DD_` prefix to env vars of AllowList, DenyList, and TagRule so these env vars can be crawled and stored on REDAPL for FrontEnd usage.

- The uninstrument `*` functions operation is triggered by stack updated. All functions that are instrumented will emit `uninstrument_status` event. Then, the uninstrument itself will trigger Lambda configuration change event and trigger instrumenter again, which then we are skipping the single lambda function instrument and emit `instrument_status` `skipped` event.
```
{"eventName":"uninstrument_status","status":"succeeded","targetFunctionName":"test-remote-instrument-node","targetFunctionArn":"arn:aws:lambda:eu-west-2:425362996713:function:test-remote-instrument-node","expectedExtensionVersion":"52","runtime":"node","reason":null}

{"eventName":"instrument_status","status":"skipped","targetFunctionName":"test-remote-instrument-node","expectedExtensionVersion":null,"runtime":null,"reason":null}
```
- [example instrument status logs](https://ddserverless.datadoghq.com/logs?query=region%3Aeu-west-2%20AND%20%40targetFunctionName%3Atest-remote-instrument-node%20&cols=service%2C%40lambda.arn&event=AgAAAY7tZx_58er7DAAAAAAAAAAYAAAAAEFZN3RaeU9OQUFEbWVQMy0zZkEyNmdCUgAAACQAAAAAMDE4ZWVkNmEtNDc3NS00NWY0LWFjMGMtZDkzYzUxMWNkNGM1&fromUser=true&index=&messageDisplay=inline&refresh_mode=paused&sort=time&storage=hot&stream_sort=time%2Casc&view=spans&viz=stream&from_ts=1713379876475&to_ts=1713380034799&live=false)

