### PR TITLE
Require DD_API_KEY none empty

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -54,6 +54,7 @@ Parameters:
     Description: >-
       The Datadog API key, which can be found from the APIs page
       (/organization-settings/api-keys).
+    AllowedPattern: ".+"
     NoEcho: true
   DdSite:
     Type: String


### PR DESCRIPTION
To avoid customers created the stack without dd api key.