### PR TITLE
[SVLS-5618] Make DD_ENV on the remote instrumenter lambda configurable

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -19,6 +19,7 @@ Metadata:
           - DdDenyList
           - DdApiKey
           - EnableCodeSigningConfigurations
+          - DdInstrumenterFunctionEnv
       - Label:
           default: Layer Versions
         Parameters:
@@ -99,6 +100,11 @@ Parameters:
     Default: '464622532012'
     Description: >- 
       have to do this so that we can use dev layer in the sandbox account   
+  DdInstrumenterFunctionEnv:
+    Type: String
+    Default: 'dev'
+    Description: >-
+      DD_ENV value for the remote instrumenter Lambda function
 
 Resources:
   CloudFormationLifeCycle:
@@ -132,7 +138,7 @@ Resources:
           DD_LOG_LEVEL: DEBUG
           DD_TRACE_DEBUG: false
           DD_SERVICE: Datadog-Instrument
-          DD_ENV: dev
+          DD_ENV: !Ref DdInstrumenterFunctionEnv
           DD_SITE: !Ref DdSite
           DD_AWS_ACCOUNT_NUMBER: !Sub '${AWS::AccountId}'
           DD_ALLOW_LIST: !Ref DdAllowList


### PR DESCRIPTION
### Context
This PR adds a `DdInstrumenterFunctionEnv` parameter to the remote instrumentation CloudFormation template. This parameter is used to populate `DD_ENV` on the remote instrumenter lambda and defaults to `dev`.

### Testing
- Ran `./publish_template.sh 0.41.4 serverless-sandbox`
- In `eu-west-2`, updated the remote instrumentation stack to use the new template
- Set `DdInstrumenterFunctionEnv` to `staging`
- Updated the stack
- Confirmed that the remote instrumenter lambda function has `DD_ENV` set to `staging`
- Set `DdInstrumenterFunctionEnv` to `staging`
- Updated the stack
- Confirmed that the remote instrumenter lambda function has `DD_ENV` set to `staging`

