### PR TITLE
Update publish template script to push to a branch

### DIFF
--- a/publish_template.sh
+++ b/publish_template.sh
@@ -127,7 +127,7 @@ echo
 echo "Serverless Sample App release process complete!"
 
 if [ "$ACCOUNT" = "prod" ] ; then
-    echo "Create and merge a pull request with the version bumps"
+    echo "Create and merge a pull request with the version bumps:"
     echo "https://github.com/DataDog/Serverless-Remote-Instrumentation/pull/new/$RELEASE_BRANCH"
     echo "Create the release with the pushed tag in GitHub:"
     echo "https://github.com/DataDog/Serverless-Remote-Instrumentation/releases/new?tag=v$SAMPLE_APP_VERSION&title=v$SAMPLE_APP_VERSION"


### PR DESCRIPTION
The `publish_template` script currently commits and pushes the template version bump directly to the prod branch. Committing directly to prod is prohibited by [this rule](https://github.com/DataDog/Serverless-Remote-Instrumentation/rules?ref=refs%2Fheads%2Fprod) (part of broader Datadog policy).

This PR updates the script to instead:
1. Commit and push changes to a release branch
2. Tell the developer to create a pull request off of the release branch