### PR TITLE
[SVLS-5652] Add an eventbridge schedule to the cloudformation stack

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -131,6 +131,11 @@ exports.handler = async (event, context) => {
       instrumentOutcome,
       config,
     );
+  } else if (
+    Object.prototype.hasOwnProperty.call(event, "event-type") &&
+    event["event-type"] === "Scheduled Instrumenter Invocation"
+  ) {
+    console.log("Received an invocation from the scheduler");
   } else {
     console.error("Unexpected event encountered. Please check event.");
   }

--- a/template.yaml
+++ b/template.yaml
@@ -336,7 +336,7 @@ Resources:
         detail-type:
           - CloudFormation Stack Status Change
         resources:
-#          - wildcard: !Sub "arn:aws:cloudformation:*:*:stack/${StackName}*/*"  -> does not work
+          # - wildcard: !Sub "arn:aws:cloudformation:*:*:stack/${StackName}*/*"  -> does not work
           # Hardcoded stack name so the customer cannot change their stack name until RC integration is released
           - wildcard: arn:aws:cloudformation:*:*:stack/datadog-remote-instrument*/*
         detail:
@@ -357,3 +357,41 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: events.amazonaws.com
       SourceArn: !GetAtt StackUpdateEventRule.Arn
+
+  LambdaSchedulerRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      Path: "/"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: scheduler.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Policies:
+      - PolicyName: root
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:InvokeFunction
+            Resource: !GetAtt LambdaFunction.Arn
+
+  LambdaInvocationScheduler:
+    Type: AWS::Scheduler::Schedule
+    Properties:
+      Description: "Schedule for invoking the instrumenter lambda function"
+      FlexibleTimeWindow:
+        Mode: "OFF"
+      Name: "datadog-remote-instrument-scheduler"
+      ScheduleExpression: rate(5 minutes)
+      State: ENABLED
+      Target:
+        Arn: !GetAtt LambdaFunction.Arn
+        RoleArn: !GetAtt LambdaSchedulerRole.Arn
+        Input: |
+            {
+                "event-type": "Scheduled Instrumenter Invocation"
+            }


### PR DESCRIPTION
Context
----
This PR adds an event bridge schedule to the remote instrumentation CF stack. This schedule invokes the remote instrumenter lambda every 5 minutes. 

Eventually, this event will be used to check RC for any updates to remote instrumentation targeting rules and re-instrument if necessary. 

In this PR, the remote instrumenter detects the event from the scheduler, emits a log, and then returns.


Testing
----
- Built a new Serverless Remote Instrumentation layer
- Updated an existing remote instrumentation stack with the new template and specified the new version of the layer
- Waited > 10 minutes
- Saw the remote instrumenter lambda's invocation metrics show 1 invocation every five minutes
- Checked the CloudWatch logs for the remote instrumenter lambda
- Saw the `Received an invocation from the scheduler` log every five minutes