### PR TITLE
[SVLS] Remote instrumenter v2 - instrumentation helpers

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -1,0 +1,156 @@
+const datadogCi = require("@datadog/datadog-ci/dist/cli.js");
+const {
+  INSTRUMENT,
+  PYTHON,
+  NODE,
+  UNINSTRUMENT,
+  IN_PROGRESS,
+  SUCCEEDED,
+  FAILED,
+} = require("./consts");
+const { logger } = require("./logger");
+const { filterFunctionsToChangeInstrumentation } = require("./functions");
+const { tagResourcesWithSlsTag, untagResourcesOfSlsTag } = require("./tag");
+
+function getExtensionAndRuntimeLayerVersion(runtime, config) {
+  const result = {
+    runtimeLayerVersion: undefined,
+    extensionVersion: config.extensionVersion,
+  };
+
+  if (runtime.includes(NODE)) {
+    result.runtimeLayerVersion = config.nodeLayerVersion;
+  } else if (runtime.includes(PYTHON)) {
+    result.runtimeLayerVersion = config.pythonLayerVersion;
+  }
+
+  return result;
+}
+exports.getExtensionAndRuntimeLayerVersion = getExtensionAndRuntimeLayerVersion;
+
+async function instrumentWithDatadogCi(
+  functionToInstrument,
+  instrument,
+  config,
+  instrumentOutcome,
+) {
+  const functionName = functionToInstrument.FunctionName;
+  const functionArn = functionToInstrument.FunctionArn;
+  const runtime = functionToInstrument.Runtime;
+
+  const cli = datadogCi.cli;
+  const layerVersionObj = getExtensionAndRuntimeLayerVersion(runtime, config);
+
+  const operationName = instrument ? INSTRUMENT : UNINSTRUMENT;
+  const operation = instrument ? "instrument" : "uninstrument";
+
+  // Construct datadog-ci command
+  let command = ["lambda", operation, "-f", functionArn];
+  if (instrument) {
+    if (layerVersionObj.runtimeLayerVersion) {
+      command.push("-v", layerVersionObj.runtimeLayerVersion.toString());
+    }
+    if (layerVersionObj.extensionVersion) {
+      command.push("-e", layerVersionObj.extensionVersion.toString());
+    }
+  } else {
+    command.push("-r", config.awsRegion);
+  }
+
+  logger.logInstrumentOutcome({
+    ddSlsEventName: operationName,
+    outcome: IN_PROGRESS,
+    targetFunctionName: functionName,
+    targetFunctionArn: functionArn,
+    expectedExtensionVersion: layerVersionObj.extensionVersion.toString(),
+    runtime,
+  });
+  logger.log(`Sending datadog-ci command: ${JSON.stringify(command)}`);
+
+  const commandExitCode = await cli.run(command);
+  const outcome = commandExitCode === 0 ? SUCCEEDED : FAILED;
+
+  logger.logInstrumentOutcome({
+    ddSlsEventName: operationName,
+    outcome: outcome,
+    targetFunctionName: functionName,
+    targetFunctionArn: functionArn,
+    expectedExtensionVersion: layerVersionObj.extensionVersion.toString(),
+    runtime: runtime,
+  });
+  if (instrument) {
+    instrumentOutcome.instrument[outcome][functionName] = { functionArn };
+  } else {
+    instrumentOutcome.uninstrument[outcome][functionName] = { functionArn };
+  }
+}
+exports.instrumentWithDatadogCi = instrumentWithDatadogCi;
+
+async function instrumentFunctions(
+  configs,
+  functionsToCheck,
+  instrumentOutcome,
+  taggingClient,
+) {
+  for (const config of configs) {
+    let {
+      functionsToInstrument,
+      functionsToUninstrument,
+      functionsToTag,
+      functionsToUntag,
+    } = filterFunctionsToChangeInstrumentation(
+      functionsToCheck,
+      config,
+      instrumentOutcome,
+    );
+    logger.log(
+      `Functions to instrument: ${functionsToInstrument.map((f) => f.FunctionName)}`,
+    );
+    logger.log(
+      `Functions to uninstrument: ${functionsToUninstrument.map((f) => f.FunctionName)}`,
+    );
+    logger.log(
+      `Functions to tag: ${functionsToTag.map((f) => f.FunctionName)}`,
+    );
+    logger.log(
+      `Functions to untag: ${functionsToUntag.map((f) => f.FunctionName)}`,
+    );
+
+    // Instrument and tag the functions that need to be instrumented
+    for (const functionToInstrument of functionsToInstrument) {
+      await instrumentWithDatadogCi(
+        functionToInstrument,
+        true,
+        config,
+        instrumentOutcome,
+      );
+    }
+    await tagResourcesWithSlsTag(
+      taggingClient,
+      functionsToTag.flatMap((f) =>
+        !(f.FunctionName in instrumentOutcome.instrument[FAILED])
+          ? f.FunctionArn
+          : [],
+      ),
+    );
+
+    // Uninstrument and untag the functions that need to be uninstrumented
+    for (const functionToUninstrument of functionsToUninstrument) {
+      await instrumentWithDatadogCi(
+        functionToUninstrument,
+        false,
+        config,
+        instrumentOutcome,
+      );
+    }
+    await untagResourcesOfSlsTag(
+      taggingClient,
+      functionsToTag.flatMap((f) =>
+        !(f.FunctionName in instrumentOutcome.uninstrument[FAILED])
+          ? f.FunctionArn
+          : [],
+      ),
+    );
+  }
+}
+exports.instrumentFunctions = instrumentFunctions;

--- a/test/instrument.test.js
+++ b/test/instrument.test.js
@@ -1,0 +1,46 @@
+const { getExtensionAndRuntimeLayerVersion } = require("../src/instrument");
+
+describe("getExtensionAndRuntimeLayerVersion", () => {
+  it("should return the layer and runtime version for node", () => {
+    const runtime = "nodejs12.x";
+    const config = {
+      extensionVersion: 1,
+      nodeLayerVersion: 2,
+      pythonLayerVersion: 3,
+    };
+    const expected = {
+      runtimeLayerVersion: 2,
+      extensionVersion: 1,
+    };
+    const actual = getExtensionAndRuntimeLayerVersion(runtime, config);
+    expect(actual).toEqual(expected);
+  });
+  it("should return the layer and runtime version for python", () => {
+    const runtime = "python3.10";
+    const config = {
+      extensionVersion: 1,
+      nodeLayerVersion: 2,
+      pythonLayerVersion: 3,
+    };
+    const expected = {
+      runtimeLayerVersion: 3,
+      extensionVersion: 1,
+    };
+    const actual = getExtensionAndRuntimeLayerVersion(runtime, config);
+    expect(actual).toEqual(expected);
+  });
+  it("should return an undefined runtime layer version for an unsupported runtime", () => {
+    const runtime = "go1.x";
+    const config = {
+      extensionVersion: 1,
+      nodeLayerVersion: 2,
+      pythonLayerVersion: 3,
+    };
+    const expected = {
+      runtimeLayerVersion: undefined,
+      extensionVersion: 1,
+    };
+    const actual = getExtensionAndRuntimeLayerVersion(runtime, config);
+    expect(actual).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Context
---
We're rewriting the remote instrumenter to fetch and use config from the remote config backend, which requires refactoring, modifying and adding to the existing remote instrumenter implementation.

You can look at the full instrumenter v2 implementation in [this draft PR](https://github.com/DataDog/Serverless-Remote-Instrumentation/pull/44) to get the full context. I'm breaking it into several PRs to be easier to review.

This PR
---
This PR adds functions for applying instrumentation changes:
- `getExtensionAndRuntimeLayerVersion` gets the extension version and appropriate layer version from config
- `instrumentWithDatadogCi` uses `datadog-ci` to apply instrumentation changes to a function
- `instrumentFunctions` loops through the provided functions and applies the necessary instrumentation changes to each one

Testing
---
- Unit tests in `instrument.test.js`, run them with `yarn test`