### PR TITLE
[SVLS] Remote instrumenter v2 - refactor main handler loop

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -40,6 +40,11 @@ exports.handler = async (event, context) => {
 
   // If it's a stack event, send a response to CloudFormation for custom resource management
   if (isStackDeletedEvent(event) || isStackCreatedEvent(event)) {
+    /**
+     * TODO: [Followup] Do one of two things:
+     * 1. On Stack Created, check all functions for instrumentation like we do for the scheduled event
+     * 2. Remove the lambda custom resource from the template and handler code
+     */
     logger.log(`Received a CloudFormation '${event.RequestType}' event.`);
     await cfnResponse.send(event, context, "SUCCESS");
   }


### PR DESCRIPTION
Context
---
We're rewriting the remote instrumenter to fetch and use config from the remote config backend, which requires refactoring, modifying and adding to the existing remote instrumenter implementation.

You can look at the full instrumenter v2 implementation in [this draft PR](https://github.com/DataDog/Serverless-Remote-Instrumentation/pull/44) to get the full context. I'm breaking it into several PRs to be easier to review.

This PR
---
This PR sets up the main handler for the remote instrumenter lambda function. 

The remote instrumenter handles three main types of events:
1. **Stack events** - just send a response back to to CloudFormation 
3. **Lambda management events** (e.g. function configuration updated, new function created) - get the function name from the event, check if that function needs to be reinstrumented, (un)instrument if necessary 
4. **Scheduled event** - check if the config in RC has changed, if yes recheck everything and reinstrument if necessary

Note: the remote instrumenter v1 code was all located in handler.js. The code has been moved out of this file or removed. Because a lot of content was removed from this file, it may be easier to review this PR by looking at the [new handler directly](https://github.com/DataDog/Serverless-Remote-Instrumentation/blob/1d5022d9467fbe20b408cdf8386af5997a83f427/src/handler.js).

Testing
---
- Build the `Datadog-Serverless-Remote-Instrumentation-ARM` layer using the `publish_sandbox` script
- Update a remote instrumenter with this layer (e.g. [the one in ca-central-1](https://ca-central-1.console.aws.amazon.com/lambda/home?region=ca-central-1#/functions/datadog-remote-instrumenter?subtab=envVars&tab=code))
- Watch the remote instrumenter instrument/uninstrument functions correctly