### PR TITLE
Move instrument metrics into instrument function

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -18,8 +18,6 @@ const { getAllFunctions, enrichFunctionsWithTags } = require("./functions");
 const { instrumentFunctions } = require("./instrument");
 const {
   LAMBDA_EVENT,
-  REMOTE_INSTRUMENTATION_STARTED,
-  REMOTE_INSTRUMENTATION_ENDED,
   SCHEDULED_INVOCATION_EVENT,
 } = require("./consts");
 
@@ -75,25 +73,12 @@ exports.handler = async (event, context) => {
       throw error;
     }
 
-    logger.emitFrontEndEvent(
-      REMOTE_INSTRUMENTATION_STARTED,
-      LAMBDA_EVENT,
-      null,
-      configs,
-    );
-
     await instrumentFunctions(
       configs,
       functionsToCheck,
       instrumentOutcome,
       taggingClient,
-    );
-
-    logger.emitFrontEndEvent(
-      REMOTE_INSTRUMENTATION_ENDED,
       LAMBDA_EVENT,
-      instrumentOutcome,
-      configs,
     );
   }
 
@@ -112,24 +97,12 @@ exports.handler = async (event, context) => {
         allFunctions,
       );
 
-      logger.emitFrontEndEvent(
-        REMOTE_INSTRUMENTATION_STARTED,
-        SCHEDULED_INVOCATION_EVENT,
-        null,
-        configs,
-      );
       await instrumentFunctions(
         configs,
         functionsToCheck,
         instrumentOutcome,
         taggingClient,
-      );
-
-      logger.emitFrontEndEvent(
-        REMOTE_INSTRUMENTATION_ENDED,
         SCHEDULED_INVOCATION_EVENT,
-        instrumentOutcome,
-        configs,
       );
 
       await updateConfigHash(s3Client, configs);

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -11,6 +11,10 @@ const {
 const { logger } = require("./logger");
 const { filterFunctionsToChangeInstrumentation } = require("./functions");
 const { tagResourcesWithSlsTag, untagResourcesOfSlsTag } = require("./tag");
+const {
+  REMOTE_INSTRUMENTATION_STARTED,
+  REMOTE_INSTRUMENTATION_ENDED,
+} = require("./consts");
 
 function getExtensionAndRuntimeLayerVersion(runtime, config) {
   const result = {
@@ -91,7 +95,14 @@ async function instrumentFunctions(
   functionsToCheck,
   instrumentOutcome,
   taggingClient,
+  triggeredBy,
 ) {
+  logger.emitFrontEndEvent(
+    REMOTE_INSTRUMENTATION_STARTED,
+    triggeredBy,
+    null,
+    configs,
+  );
   for (const config of configs) {
     let {
       functionsToInstrument,
@@ -152,5 +163,11 @@ async function instrumentFunctions(
       ),
     );
   }
+  logger.emitFrontEndEvent(
+    REMOTE_INSTRUMENTATION_ENDED,
+    triggeredBy,
+    instrumentOutcome,
+    configs,
+  );
 }
 exports.instrumentFunctions = instrumentFunctions;

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -4,6 +4,7 @@ const config = require("../src/config");
 const lambdaEvent = require("../src/lambda-event");
 const instrument = require("../src/instrument");
 const errorStorage = require("../src/error-storage");
+const { LAMBDA_EVENT } = require("../src/consts");
 
 jest.mock("../src/lambda-event");
 jest.mock("../src/config");
@@ -39,7 +40,7 @@ describe("handler lambda management events", () => {
     expect(lambdaEvent.getFunctionFromLambdaEvent).toHaveBeenCalledWith(expect.anything(), event);
     expect(functions.enrichFunctionsWithTags).toHaveBeenCalledWith(expect.anything(), [lambdaFunction]);
     expect(config.getConfigs).toHaveBeenCalledWith(context);
-    expect(instrument.instrumentFunctions).toHaveBeenCalledWith(configsResult, enrichedFunction, expect.anything(), expect.anything());
+    expect(instrument.instrumentFunctions).toHaveBeenCalledWith(configsResult, enrichedFunction, expect.anything(), expect.anything(), LAMBDA_EVENT);
     expect(errorStorage.putError).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
# Notes
Move emitting metrics for the front end from the same place instrument was being called, so you would have to remember to call it, to inside the instrument function.  This means that where ever the instrument function is called from, the metric will be emitted and we don't need to remember to do it.

I'm doing this ahead of adding a third place that would need this same logic, so I pulled it out into the function before doing that change.

# Testing
* Small unit test changes.
* Deployed to the sandbox remote instrumenter lambda, manually checked it is still working

# Open Question
1. Where do these metrics go?  They look like they're just logged to CloudWatch, but I don't see a metric filter or anything like that in the CloudFormation stack.

# Documentation
* JIRA: https://datadoghq.atlassian.net/browse/SVLS-6102