### PR TITLE
Read errors back from s3

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,7 @@ const { ENTITY_TYPES, FILTER_TYPES } = require("./consts");
 
 const REMOTE_CONFIG_PRODUCT = "SERVERLESS_REMOTE_INSTRUMENTATION";
 const REMOTE_CONFIG_URL = "http://localhost:8126/v0.7/config";
+const KEY = "datadog_remote_instrumentation_config.txt";
 
 class RcConfig {
   constructor(configJSON) {
@@ -226,12 +227,11 @@ async function configHasChanged(client, configs) {
     .update(JSON.stringify(configs))
     .digest("hex");
   const bucketName = process.env.DD_S3_BUCKET;
-  const key = "datadog_remote_instrumentation_config.txt";
   try {
     const response = await client.send(
       new GetObjectCommand({
         Bucket: bucketName,
-        Key: key,
+        Key: KEY,
       }),
     );
     const oldConfigHash = await response.Body.transformToString();
@@ -243,7 +243,7 @@ async function configHasChanged(client, configs) {
   } catch (caught) {
     if (caught instanceof NoSuchKey) {
       logger.error(
-        `Error from S3 while getting object "${key}" from "${bucketName}". No such key exists.`,
+        `Error from S3 while getting object "${KEY}" from "${bucketName}". No such key exists.`,
       );
       return true;
     } else if (caught instanceof S3ServiceException) {
@@ -265,10 +265,9 @@ async function updateConfigHash(client, configs) {
     .update(JSON.stringify(configs))
     .digest("hex");
   const bucketName = process.env.DD_S3_BUCKET;
-  const key = "config.txt";
   const command = new PutObjectCommand({
     Bucket: bucketName,
-    Key: key,
+    Key: KEY,
     Body: newConfigHash,
   });
 

--- a/src/error-storage.js
+++ b/src/error-storage.js
@@ -1,11 +1,13 @@
-const { PutObjectCommand } = require("@aws-sdk/client-s3");
+const { ListObjectsV2Command, PutObjectCommand } = require("@aws-sdk/client-s3");
 
 const bucketName = process.env.DD_S3_BUCKET;
+const prefix = 'errors/';
+const suffix = '.json';
 
 const putError = async (s3, functionName, error) => {
   const command = new PutObjectCommand({
     Bucket: bucketName,
-    Key: `errors/${functionName}.json`,
+    Key: `${prefix}${functionName}${suffix}`,
     Body: JSON.stringify({
       functionName,
       error,
@@ -16,3 +18,29 @@ const putError = async (s3, functionName, error) => {
 };
 
 exports.putError = putError;
+
+const listErrors = async (s3) => {
+  const params = {
+    Bucket: bucketName,
+    Prefix: prefix,
+  };
+  
+  let isTruncated = true;
+  const results = [];
+
+  while (isTruncated) {
+    const command = new ListObjectsV2Command(params);
+    const response = await s3.send(command);
+    const {
+      Contents,
+      NextContinuationToken,
+    } = response;
+    isTruncated = response.IsTruncated;
+    results.push(...Contents);
+    params.ContinuationToken = NextContinuationToken;
+  }
+  // Return just the LAMBDA_FUNCTION_NAME from `errors/LAMBDA_FUNCTION_NAME.json`
+  return results.map(item => item.Key.slice(prefix.length, item.Key.length - suffix.length));
+};
+
+exports.listErrors = listErrors;

--- a/src/functions.js
+++ b/src/functions.js
@@ -63,7 +63,7 @@ async function getAllFunctions(client) {
   allFunctions.push(...listFunctionsCommandOutput.Functions);
 
   let nextMarker = listFunctionsCommandOutput.NextMarker;
-  while (nextMarker !== null) {
+  while (nextMarker) {
     const listFunctionsCommand = new ListFunctionsCommand({
       Marker: nextMarker,
     });

--- a/test/error-storage.test.js
+++ b/test/error-storage.test.js
@@ -1,0 +1,74 @@
+const { listErrors } = require("../src/error-storage");
+
+const mockS3 = {
+  send: jest.fn(),
+};
+
+describe("listErrors test suite", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("handles one page of results", async () => {
+    const mockResult = {
+      IsTruncated: false,
+      Contents: [{
+        Key: 'errors/key1.json',
+      }, {
+        Key: 'errors/key2.json',
+      }]
+    };
+    mockS3.send.mockReturnValue(mockResult);
+    const result = await listErrors(mockS3);
+
+    expect(result).toStrictEqual(['key1', 'key2']);
+    expect(mockS3.send).toHaveBeenCalledTimes(1);
+  });
+
+  test("handles multiple pages of results", async () => {
+    const mockResult1 = {
+      IsTruncated: true,
+      Contents: [{
+        Key: 'errors/key1.json',
+      }, {
+        Key: 'errors/key2.json',
+      }],
+      NextContinuationToken: 'A',
+    };
+    const mockResult2 = {
+      IsTruncated: true,
+      Contents: [{
+        Key: 'errors/key3.json',
+      }, {
+        Key: 'errors/key4.json',
+      }],
+      NextContinuationToken: 'B',
+    };
+    const mockResult3 = {
+      IsTruncated: false,
+      Contents: [{
+        Key: 'errors/key5.json',
+      }],
+    };
+    mockS3.send.mockReturnValueOnce(mockResult1);
+    mockS3.send.mockReturnValueOnce(mockResult2);
+    mockS3.send.mockReturnValueOnce(mockResult3);
+
+    const result = await listErrors(mockS3);
+
+    expect(result).toStrictEqual(['key1', 'key2', 'key3', 'key4', 'key5']);
+    expect(mockS3.send).toHaveBeenCalledTimes(3);
+  });
+
+  test("handles no results", async () => {
+    const mockResult = {
+      IsTruncated: false,
+      Contents: []
+    };
+    mockS3.send.mockReturnValue(mockResult);
+    const result = await listErrors(mockS3);
+
+    expect(result).toStrictEqual([]);
+    expect(mockS3.send).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# Notes
When instrumenting a function from a lambda management event fails, the error will be written to an s3 object errors/{lambda function name}.json. This commit lists all of the errors and parses the lambda function name out. If there are any functions that failed on a lambda management event, the scheduled invocation will see the s3 object and try to instrument the function.

Also fix some small bugs discovered during testing where a while loop wasn't terminating or that the config wasn't found after it was saved since the s3 keys were different.



# Testing
* Unit tests
* Manually tested using [this function in the serverless sandbox account](https://ca-central-1.console.aws.amazon.com/lambda/home?region=ca-central-1#/functions/datadog-remote-instrumenter?code=&subtab=envVars&tab=testing).  You can try it out in using this test event:
* 
```
{
  "event-type": "Scheduled Instrumenter Invocation"
}
```

# Open Questions
1. I'm assuming here that if the remote instrumenter config changes that by checking all of the lambda functions it will detect that there were functions that had errored before, and therefore don't need to be run explicitly.  Just wanted to confirm this is true.  In code, if [this sections](https://github.com/DataDog/Serverless-Remote-Instrumentation/blob/tal.usvyatsky/rewrite-instrumenter-logic/src/handler.js#L91-L108) runs, then I don't need to run this.
2. Do we have a way to run integration tests for this?  Some of the manual testing I've been doing is a bit of a pain to verify that it all works, and I'd love to be able to just run a test suite to check that it works

# Next Steps
1. The next step in this will be to delete the file from S3 once the error has been resolved.
3. There is also a failed section of the instrumentation outcome.  Those are not yet getting to S3 but (I think) should be

# Documentation
JIRA: https://datadoghq.atlassian.net/browse/SVLS-6102