### PR TITLE
Delete handled s3 errors and add failures to s3

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -172,6 +172,7 @@ Resources:
             Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*
           - Effect: Allow
             Action:
+              - s3:DeleteObject
               - s3:ListBucket
               - s3:GetObject
               - s3:PutObject

--- a/test/error-storage.test.js
+++ b/test/error-storage.test.js
@@ -1,4 +1,5 @@
-const { listErrors } = require("../src/error-storage");
+const { identifyNewErrorsAndResolvedErrors, listErrors } = require("../src/error-storage");
+const { FAILED, SKIPPED, SUCCEEDED } = require("../src/consts");
 
 const mockS3 = {
   send: jest.fn(),
@@ -22,6 +23,22 @@ describe("listErrors test suite", () => {
     const result = await listErrors(mockS3);
 
     expect(result).toStrictEqual(['key1', 'key2']);
+    expect(mockS3.send).toHaveBeenCalledTimes(1);
+  });
+
+  test("handles when errors/ is a folder object and should be filtered in the result", async () => {
+    const mockResult = {
+      IsTruncated: false,
+      Contents: [{
+        Key: 'errors/',
+      }, {
+        Key: 'errors/key.json',
+      }]
+    };
+    mockS3.send.mockReturnValue(mockResult);
+    const result = await listErrors(mockS3);
+
+    expect(result).toStrictEqual(['key']);
     expect(mockS3.send).toHaveBeenCalledTimes(1);
   });
 
@@ -72,3 +89,203 @@ describe("listErrors test suite", () => {
     expect(mockS3.send).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("identifyErrorsAndResolvedErrors test suite", () => {
+  test.each([
+    [
+      "nothing happened, no errors, nothing returned",
+      {
+        instrument: {
+          [FAILED]: {},
+          [SKIPPED]: {},
+          [SUCCEEDED]: {},
+        },
+        uninstrument: {
+          [FAILED]: {},
+          [SKIPPED]: {},
+          [SUCCEEDED]: {},
+        },
+      },
+      [],
+      {
+        newErrors: [],
+        resolvedErrors: []
+      },
+    ],
+    [
+      "previous error not in results",
+      {
+        instrument: {
+          [FAILED]: {},
+          [SKIPPED]: {},
+          [SUCCEEDED]: {},
+        },
+        uninstrument: {
+          [FAILED]: {},
+          [SKIPPED]: {},
+          [SUCCEEDED]: {},
+        },
+      },
+      ["I'm not here!"],
+      {
+        newErrors: [],
+        resolvedErrors: []
+      },
+    ],
+    [
+      "only success / skips, no errors, nothing returned",
+      {
+        instrument: {
+          [FAILED]: {},
+          [SKIPPED]: {
+            function1: {}
+          },
+          [SUCCEEDED]: {
+            function2: {}
+          },
+        },
+        uninstrument: {
+          [FAILED]: {},
+          [SKIPPED]: {
+            function1: {},
+          },
+          [SUCCEEDED]: {
+            function1: {},
+          },
+        },
+      },
+      [],
+      {
+        newErrors: [],
+        resolvedErrors: []
+      },
+    ],
+    [
+      "failures are added to the newErrors",
+      {
+        instrument: {
+          [FAILED]: {
+            failure1: {
+              reason: 'failure1 - reason',
+            },
+          },
+          [SKIPPED]: {
+            function1: {},
+          },
+          [SUCCEEDED]: {
+            function2: {},
+          },
+        },
+        uninstrument: {
+          [FAILED]: {
+            failure2: {
+              reason: 'failure2 - reason',
+            },
+          },
+          [SKIPPED]: {
+            function1: {},
+          },
+          [SUCCEEDED]: {
+            function1: {},
+          },
+        },
+      },
+      [],
+      {
+        newErrors: [{
+          functionName: 'failure1',
+          reason: 'failure1 - reason',
+        }, {
+          functionName: 'failure2',
+          reason: 'failure2 - reason',
+        },],
+        resolvedErrors: [],
+      },
+    ],
+    [
+      "successes and skips are added to the resolvedErrors",
+      {
+        instrument: {
+          [FAILED]: {},
+          [SKIPPED]: {
+            function1: {},
+          },
+          [SUCCEEDED]: {
+            function2: {},
+          },
+        },
+        uninstrument: {
+          [FAILED]: {},
+          [SKIPPED]: {
+            function3: {},
+          },
+          [SUCCEEDED]: {
+            function4: {},
+          },
+        },
+      },
+      ['function1', 'function4'],
+      {
+        newErrors: [],
+        resolvedErrors: ['function1', 'function4'],
+      },
+    ],
+    [
+      "both failures and successes get mapped in the same execution",
+      {
+        instrument: {
+          [FAILED]: {
+            failure1: {
+              reason: 'failure1 - reason',
+            },
+            failure1a: {
+              reason: 'failure1a - reason',
+            },
+          },
+          [SKIPPED]: {
+            function1: {},
+            function1a: {},
+          },
+          [SUCCEEDED]: {
+            function2: {},
+          },
+        },
+        uninstrument: {
+          [FAILED]: {
+            failure2: {
+              reason: 'failure2 - reason',
+            },
+            failure2a: {
+              reason: 'failure2a - reason',
+            },
+          },
+          [SKIPPED]: {
+            function3: {},
+            function3a: {},
+          },
+          [SUCCEEDED]: {
+            function4: {},
+          },
+        },
+      },
+      ['function1', 'function1a', 'failure1a', 'function4', 'I do not exist!'],
+      {
+        newErrors: [{
+          functionName: 'failure1',
+          reason: 'failure1 - reason',
+        }, {
+          functionName: 'failure2',
+          reason: 'failure2 - reason',
+        }, {
+          functionName: 'failure2a',
+          reason: 'failure2a - reason',
+        }],
+        resolvedErrors: ['function1', 'function1a', 'function4'],
+      },
+    ],
+  ])("%s", (_, instrumentOutcome, previousErrors, expected) => {
+    const result = identifyNewErrorsAndResolvedErrors(instrumentOutcome, previousErrors);
+    expect(result).toStrictEqual(expected);
+  });
+});
+

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -88,12 +88,18 @@ describe("scheduled invocation events", () => {
     config.getConfigs.mockReturnValue(configsResult);
     config.configHasChanged.mockReturnValue(false)
     errorStorage.listErrors.mockReturnValue(['function1', 'function2']);
+    errorStorage.putError.mockReturnValue(true);
+    errorStorage.deleteError.mockReturnValue(true);
     instrument.instrumentFunctions.mockReturnValue(true);
     functions.getLambdaFunction.mockReturnValue({
       Configuration: { key: 'configuration' },
       Tags: 'tags',
     });
     functions.enrichFunctionsWithTags.mockReturnValue('A');
+    errorStorage.identifyNewErrorsAndResolvedErrors.mockReturnValue({
+      newErrors: [{ functionName: 'name', reason: 'reason'}],
+      resolvedErrors: ['error!'],
+    });
 
     await handler.handler(event, context);
 
@@ -104,5 +110,9 @@ describe("scheduled invocation events", () => {
     expect(functions.enrichFunctionsWithTags).toHaveBeenCalledTimes(1);
     expect(instrument.instrumentFunctions).toHaveBeenCalledTimes(1);
     expect(instrument.instrumentFunctions).toHaveBeenCalledWith(configsResult, 'A', expect.anything(), expect.anything());
+    expect(errorStorage.putError).toHaveBeenCalledTimes(1);
+    expect(errorStorage.putError).toHaveBeenCalledWith(expect.anything(), 'name', 'reason');
+    expect(errorStorage.deleteError).toHaveBeenCalledTimes(1);
+    expect(errorStorage.deleteError).toHaveBeenCalledWith(expect.anything(), 'error!');
   });
 });


### PR DESCRIPTION
# Notes
Add failures from other causes to S3 to retry on the next scheduled invocation.  Also delete the object in s3 when it is successfully retried, and give the lambda permissions to do that.

# Testing
* Unit tests
* Manually deployed, confirmed the instrumenter is deleting the S3 objects with the error information.  In the [serverless sandbox account (the link will sign you in)](https://d-906757b57c.awsapps.com/start/#/console?account_id=425362996713&role_name=account-admin-8h), layer Datadog-Serverless-Remote-Instrumentation-ARM-Alex-Testing version 53 on [this function](https://ca-central-1.console.aws.amazon.com/lambda/home?region=ca-central-1#/functions/datadog-remote-instrumenter?code=&subtab=permissions&tab=code) has the version of the code in this PR.  You can test instrumenting after an error by putting an object in [this bucket](https://ca-central-1.console.aws.amazon.com/s3/buckets/datadog-remote-instrument-bucket-97ee62b0?region=ca-central-1&bucketType=general&tab=objects) with a key `errors/${functionName}.json`, for example `errors/tal-hello-world.json`.  The contents can be anything.  Then invoke the lambda function above with the scheduler payload, or wait a few minutes for it to run.  The object in S3 will be deleted and you should see the function instrumented.
 
```
{
  "event-type": "Scheduled Instrumenter Invocation"
}
```

# Documentation
* JIRA https://datadoghq.atlassian.net/browse/SVLS-6102

# Next steps
1. I'd like to also do a few repo things around testing / linting  and things like that
2. Both Tal's and my changes over the last couple of weeks have been into this non prod branch.  This all should get merged in