### PR TITLE
Add integration test framework

### DIFF
--- a/integration-tests/error-handling.test.js
+++ b/integration-tests/error-handling.test.js
@@ -1,0 +1,73 @@
+const { getCredentials } = require("./utilities/get-credentials");
+const {
+  isFunctionInstrumented,
+} = require("./utilities/is-function-instrumented");
+const {
+  deleteErrorObject,
+  doesErrorObjectExist,
+  putErrorObject,
+} = require("./utilities/s3-error-object");
+const {
+  invokeLambdaWithScheduledEvent,
+} = require("./utilities/remote-instrumenter-invocations");
+const { S3Client } = require("@aws-sdk/client-s3");
+const { LambdaClient } = require("@aws-sdk/client-lambda");
+
+// Inputs that are needed.  These will eventually be derived in
+// future PRs so that we don't need to manually specify them.
+const arn = "arn:aws:iam::425362996713:role/alex-angelillo-test";
+const bucket = "datadog-remote-instrument-bucket-97ee62b0";
+const remoteInstrumenterName = "datadog-remote-instrumenter";
+const region = "ca-central-1";
+
+const credentials = getCredentials(arn);
+const s3 = new S3Client({
+  credentials,
+  region,
+});
+
+const lambdaClient = new LambdaClient({
+  credentials,
+  region,
+});
+
+describe("Error handling tests", () => {
+  const testFunction = "tal-hello-world";
+
+  afterAll(async () => {
+    await deleteErrorObject(s3, bucket, testFunction);
+  });
+  it("reads an s3 file and instruments the lambda", async () => {
+    // When there is an error for a function
+    await putErrorObject(s3, bucket, testFunction);
+
+    // And the scheduler runs
+    const instrumentOutcome = await invokeLambdaWithScheduledEvent(
+      lambdaClient,
+      remoteInstrumenterName,
+    );
+
+    // Then the error object is deleted
+    const objectExistsAfterInvocation = await doesErrorObjectExist(
+      s3,
+      bucket,
+      testFunction,
+    );
+    expect(objectExistsAfterInvocation).toStrictEqual(false);
+
+    // And the response skipped the function
+    expect(Object.keys(instrumentOutcome.instrument.skipped)).toStrictEqual([
+      testFunction,
+    ]);
+    expect(
+      instrumentOutcome.instrument.skipped[testFunction].reasonCode,
+    ).toStrictEqual("already-correct-extension-and-layer");
+
+    // Because the function is instrumented
+    const isInstrumented = await isFunctionInstrumented(
+      lambdaClient,
+      testFunction,
+    );
+    expect(isInstrumented).toStrictEqual(true);
+  });
+});

--- a/integration-tests/jest.config.js
+++ b/integration-tests/jest.config.js
@@ -1,0 +1,6 @@
+const config = {
+  testMatch: ["**/integration-tests/**+(test|spec).[jt]s?(x)"],
+  testTimeout: 60000, // ms
+};
+
+module.exports = config;

--- a/integration-tests/utilities/get-credentials.js
+++ b/integration-tests/utilities/get-credentials.js
@@ -1,0 +1,22 @@
+const { execSync } = require("child_process");
+
+const creds = {};
+
+const getCredentials = (arn) => {
+  if (!creds[arn]) {
+    const output = execSync(
+      "aws-vault exec sso-serverless-sandbox-account-admin -- " +
+        `aws sts assume-role --role-arn ${arn} --role-session-name testing`,
+      { encoding: "utf-8" },
+    );
+    const misNamedCreds = JSON.parse(output).Credentials;
+    creds[arn] = {
+      accessKeyId: misNamedCreds.AccessKeyId,
+      secretAccessKey: misNamedCreds.SecretAccessKey,
+      sessionToken: misNamedCreds.SessionToken,
+    };
+  }
+  return creds[arn];
+};
+
+exports.getCredentials = getCredentials;

--- a/integration-tests/utilities/is-function-instrumented.js
+++ b/integration-tests/utilities/is-function-instrumented.js
@@ -1,0 +1,30 @@
+const { GetFunctionConfigurationCommand } = require("@aws-sdk/client-lambda");
+
+const hasLayerMatching = (l, matcher) =>
+  l.Layers.some((layer) => layer.Arn.includes(matcher));
+const hasEnvVar = (l, varName) =>
+  Object.keys(l.Environment.Variables).includes(varName);
+
+// A function is considered instrumented if all are true:
+// 1. It has the Datadog-Extension layer
+// 2. It has a language specific datadog layer (Datadog-Python, Datadog-Node, etc)
+// 3. It has the DD_API_KEY and DD_SITE environment variables
+const isFunctionInstrumented = async (lambda, functionName) => {
+  const funConfig = await lambda.send(
+    new GetFunctionConfigurationCommand({
+      FunctionName: functionName,
+    }),
+  );
+  return (
+    hasLayerMatching(funConfig, "Datadog-Extension") &&
+    (hasLayerMatching(funConfig, "Datadog-Python") ||
+      hasLayerMatching(funConfig, "Datadog-Node") ||
+      hasLayerMatching(funConfig, "dd-trace-java") ||
+      hasLayerMatching(funConfig, "dd-trace-dotnet") ||
+      hasLayerMatching(funConfig, "Datadog-Ruby")) &&
+    hasEnvVar(funConfig, "DD_API_KEY") &&
+    hasEnvVar(funConfig, "DD_SITE")
+  );
+};
+
+exports.isFunctionInstrumented = isFunctionInstrumented;

--- a/integration-tests/utilities/remote-instrumenter-invocations.js
+++ b/integration-tests/utilities/remote-instrumenter-invocations.js
@@ -1,0 +1,17 @@
+const { InvokeCommand } = require("@aws-sdk/client-lambda");
+
+const invokeLambdaWithScheduledEvent = async (
+  lambda,
+  remoteInstrumenterName,
+) => {
+  const command = new InvokeCommand({
+    FunctionName: remoteInstrumenterName,
+    Payload: JSON.stringify({
+      "event-type": "Scheduled Instrumenter Invocation",
+    }),
+  });
+  const { Payload } = await lambda.send(command);
+  return JSON.parse(Buffer.from(Payload).toString());
+};
+
+exports.invokeLambdaWithScheduledEvent = invokeLambdaWithScheduledEvent;

--- a/integration-tests/utilities/s3-error-object.js
+++ b/integration-tests/utilities/s3-error-object.js
@@ -1,0 +1,47 @@
+const {
+  DeleteObjectCommand,
+  PutObjectCommand,
+  HeadObjectCommand,
+  NotFound,
+} = require("@aws-sdk/client-s3");
+
+const putErrorObject = async (s3, bucket, functionName) => {
+  const command = new PutObjectCommand({
+    Bucket: bucket,
+    Key: `errors/${functionName}.json`,
+    Body: JSON.stringify({ functionName }),
+  });
+
+  return s3.send(command);
+};
+
+exports.putErrorObject = putErrorObject;
+
+const deleteErrorObject = async (s3, bucket, functionName) => {
+  const command = new DeleteObjectCommand({
+    Bucket: bucket,
+    Key: `errors/${functionName}.json`,
+  });
+
+  return s3.send(command);
+};
+
+exports.deleteErrorObject = deleteErrorObject;
+
+const doesErrorObjectExist = async (s3, bucket, functionName) => {
+  const command = new HeadObjectCommand({
+    Bucket: bucket,
+    Key: `errors/${functionName}.json`,
+  });
+  try {
+    await s3.send(command);
+    return true;
+  } catch (error) {
+    if (error instanceof NotFound) {
+      return false;
+    }
+    throw error;
+  }
+};
+
+exports.doesErrorObjectExist = doesErrorObjectExist;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "format": "eslint --fix . self-monitoring-app/modifier_handler.js",
     "lint": "eslint -c eslint.config.mjs . ",
-    "test": "jest"
+    "test": "jest --config test/jest.config.js",
+    "integ": "jest --config integration-tests/jest.config.js"
   }
 }

--- a/src/handler.js
+++ b/src/handler.js
@@ -167,4 +167,6 @@ exports.handler = async (event, context) => {
   else {
     console.error("Received unexpected event type");
   }
+
+  return instrumentOutcome;
 };

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -1,0 +1,5 @@
+const config = {
+  testMatch: ["**/test/**+(test|spec).[jt]s?(x)"],
+};
+
+module.exports = config;


### PR DESCRIPTION
# Notes
Add the framework for us to do integration tests, along with an initial test. I separated out the unit and integration test runs by using jest configs for each of them so that they can be run separately.  The existing integration test will assume a role and use that for accessing AWS resources.  The test that is there now writes a file to S3 and invokes the remote instrumenter lambda in the same way the 5 minute scheduled invocations do, then asserts some things about the output.  To do this I had to also return the instrumentation outcome from the lambda.

My intention behind having these tests is so that we can have tests close to what we want customers to be doing, and because we will have those tests we will know if the remote instrumenter is working or not.  These should be at the level of "When a customer creates a lambda matching the remote instrumentation tags, that function becomes instrumented" and not tied to any way that we implement this.

This is a bit of the first step towards doing more with this kind of testing. The thing I would want to work towards (if we decide that this is the direction we want to go) is towards increasing how automated this is.  Those steps roughly include

1. Automating setup of these resources (as well as test specific resources) so that you can run a single command and have a fresh test setup, and tear it down as easily.
2. Making the 4 config inputs automatically pulled in based on that setup
3. Run this all in a github action so that we know each PR will pass

# Testing
* `yarn integ` and `yarn test` pass.
* I've confirmed that the isntrumenter is running by changing the return value of the function to return the instrumentation outcome as well, and asserting things about that in the response.

# Open Questions
1. This is mostly based on what I've found useful in the past and my fairly limited experience working on the remote instrumenter over the last couple of weeks.  Fully fleshing this out is probably going to take a few days, so before I do that:  **Do people think this is a useful addition?**
2. The way that I'm getting the credentials works but felt a little wrong.  I couldn't find a javascript library for `aws-vault`, does something equivalent to that exist?