### PR TITLE
[SVLS] Update remote instrumenter to use extension v68

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -102,7 +102,7 @@ Resources:
       Role: !GetAtt LambdaExecutionRole.Arn
       Handler: /opt/nodejs/node_modules/datadog-remote-instrument/handler.handler
       Layers:
-        - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:50'
+        - !Sub 'arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:68'
         - !Sub 'arn:aws:lambda:${AWS::Region}:${DdRemoteInstrumentLayerAwsAccount}:layer:Datadog-Serverless-Remote-Instrumentation-ARM:${DdRemoteInstrumentLayerVersion}'
       Environment:
         Variables:
@@ -119,6 +119,7 @@ Resources:
           DD_S3_BUCKET: !Ref S3Bucket
           DD_REMOTE_CONFIGURATION_ENABLED: true
           DD_APM_ENABLED: true
+          DD_EXTENSION_VERSION: compatibility
       Tags:
         - Key: "dd_serverless_service"
           Value: "remote_instrumenter"


### PR DESCRIPTION
In order to retrieve instrumentation configs from the remote config (RC) platform, the remote instrumenter needs to be outfitted with an RC-enabled extension layer. Support for RC was introduced in the Go extension in v68. 

This PR updates the remote instrumentation CloudFormation template to set extension v68 on the remote instrumenter. This PR also sets `DD_EXTENSION_VERSION=compatibility` which enables the "old" Go extension instead of the next-generation non-RC-enabled Rust extension.