### PR TITLE
Check node modules install

### DIFF
--- a/scripts/build_layer.sh
+++ b/scripts/build_layer.sh
@@ -12,6 +12,14 @@ rm -rf scripts/.layers
 yarn install --production
 mkdir -p scripts/.layers
 
+if [ ! -d "node_modules" ]; then
+  yarn workspaces focus --production
+  if [ ! -d "node_modules" ]; then
+    echo "Failed to install node modules"
+    exit 1
+  fi
+fi
+
 # nodejs is the designated directory specified in Lambda documentation
 mkdir -p nodejs
 cp -r node_modules nodejs/


### PR DESCRIPTION
# Notes
Check if node modules is installed and fallback to using workspace focus instead of install since sometimes install doens't work.  If neither of those result in node_modules existing, exit the script.

# Testing
* Previously my layer didn't work on its own since it didn't have the dependencies, but not it does