### PR TITLE
Add YAML linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,3 +21,6 @@ jobs:
 
       - name: Run linter
         run: yarn lint
+      
+      - name: Run YAML linter
+        run: yarn lint-yaml

--- a/eslint.config.yaml.mjs
+++ b/eslint.config.yaml.mjs
@@ -1,0 +1,3 @@
+import eslintPluginYml from "eslint-plugin-yml";
+
+export default [...eslintPluginYml.configs["flat/recommended"]];

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jest": "^28.10.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "eslint-plugin-yml": "^1.16.0",
     "globals": "^15.1.0",
     "jest": "^29.7.0",
     "prettier": "^3.1.0",
@@ -28,6 +29,8 @@
   "scripts": {
     "format": "eslint --fix . self-monitoring-app/modifier_handler.js",
     "lint": "eslint -c eslint.config.mjs . ",
+    "lint-yaml": "eslint -c eslint.config.yaml.mjs . ",
+    "format-yaml": "eslint --fix -c eslint.config.yaml.mjs . ",
     "test": "jest --config test/jest.config.js",
     "integ": "jest --config integration-tests/jest.config.js",
     "integ-test-setup": "node scripts/test_setup.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5824,6 +5824,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-compat-utils@npm:^0.6.0":
+  version: 0.6.4
+  resolution: "eslint-compat-utils@npm:0.6.4"
+  dependencies:
+    semver: "npm:^7.5.4"
+  peerDependencies:
+    eslint: ">=6.0.0"
+  checksum: 10c0/5b665c4051e978b9f9c48621f63d07e6b2a8ba1b334fc430f1ce0d8b596968677bdb54c23c00ca961ad5b4673d5e83e014a52b4baf9a2f7d4ccd79e3c213acfb
+  languageName: node
+  linkType: hard
+
 "eslint-config-prettier@npm:^9.1.0":
   version: 9.1.0
   resolution: "eslint-config-prettier@npm:9.1.0"
@@ -5873,6 +5884,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-yml@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "eslint-plugin-yml@npm:1.16.0"
+  dependencies:
+    debug: "npm:^4.3.2"
+    eslint-compat-utils: "npm:^0.6.0"
+    lodash: "npm:^4.17.21"
+    natural-compare: "npm:^1.4.0"
+    yaml-eslint-parser: "npm:^1.2.1"
+  peerDependencies:
+    eslint: ">=6.0.0"
+  checksum: 10c0/35052c2f77fb1d143141329444ca975dbc3190393595051ce4890b7f990aaf79286b52ff18c8ffb66e9739ad779fb23efe0eb9011e761d2b26a3244e20e5a925
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:^7.1.1, eslint-scope@npm:^7.2.2":
   version: 7.2.2
   resolution: "eslint-scope@npm:7.2.2"
@@ -5883,7 +5909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
+"eslint-visitor-keys@npm:^3.0.0, eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
   version: 3.4.3
   resolution: "eslint-visitor-keys@npm:3.4.3"
   checksum: 10c0/92708e882c0a5ffd88c23c0b404ac1628cf20104a108c745f240a13c332a11aac54f49a22d5762efbffc18ecbc9a580d1b7ad034bf5f3cc3307e5cbff2ec9820
@@ -8864,6 +8890,7 @@ __metadata:
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-jest: "npm:^28.10.0"
     eslint-plugin-prettier: "npm:^5.2.1"
+    eslint-plugin-yml: "npm:^1.16.0"
     globals: "npm:^15.1.0"
     jest: "npm:^29.7.0"
     prettier: "npm:^3.1.0"
@@ -9880,10 +9907,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml-eslint-parser@npm:^1.2.1":
+  version: 1.2.3
+  resolution: "yaml-eslint-parser@npm:1.2.3"
+  dependencies:
+    eslint-visitor-keys: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    yaml: "npm:^2.0.0"
+  checksum: 10c0/dc2263f3e83ea8958d882f355039a2b72b4852a9492545fb7753fae070b1e73e211d2555318fb3ab8a4c7545d8f9b4e4670ffa5ef63d54622b3483de7401f633
+  languageName: node
+  linkType: hard
+
 "yaml@npm:1.10.2":
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: 10c0/5c28b9eb7adc46544f28d9a8d20c5b3cb1215a886609a2fd41f51628d8aaa5878ccd628b755dbcd29f6bb4921bd04ffbc6dcc370689bb96e594e2f9813d2605f
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.0.0":
+  version: 2.7.0
+  resolution: "yaml@npm:2.7.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/886a7d2abbd70704b79f1d2d05fe9fb0aa63aefb86e1cb9991837dced65193d300f5554747a872b4b10ae9a12bc5d5327e4d04205f70336e863e35e89d8f4ea9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Notes
Followup from my last PR where Tal noticed that the stack didn't deploy on the AWS UI, but it did when it was from the CLI like I was testing. Added this linter step which did catch the parsing error.  After the fix that is currently on prod, there are no yaml errors.

# Testing
* Error with old code:
```
/Users/alex.angelillo/go/src/github.com/DataDog/Serverless-Remote-Instrumentation/template.yaml
  243:8  error  Parsing error: Block collections are not allowed within flow collections

✖ 1 problem (1 error, 0 warnings)
```
* Currently shows no errors

# Documentation
* Previous PR: https://github.com/DataDog/Serverless-Remote-Instrumentation/pull/64#discussion_r1913745938
