### PR TITLE
Run integration test in github action

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,64 @@
+name: Integration Tests
+permissions:
+  contents: read
+  id-token: write
+env:
+  RUNNING_IN_GITHUB_ACTION: true
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: "ca-central-1"
+
+on: [pull_request]
+
+jobs:
+  Integration-tests:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      layer_version: ${{ steps.publish.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+
+      - name: Set up Node 20
+        uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Publish layer
+        run: yarn integ-test-publish
+
+      - name: Copy layer version for teardown
+        id: publish
+        run: echo version="$(cat scripts/.layers/version)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Infrastructure
+        run: yarn integ-test-setup
+      
+      - name: Run Integration Tests
+        run: yarn integ
+  Cleanup:
+    runs-on: ubuntu-latest
+    needs: ["Integration-tests"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+
+      - name: Set up Node 20
+        uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Pull in version
+        env:
+          LAYER_VERSION: ${{needs.Integration-tests.outputs.layer_version}}
+        run: mkdir -p scripts/.layers/ && echo $LAYER_VERSION >> scripts/.layers/version
+
+      - name: Teardown Integration Test Infrastructure
+        run: yarn integ-test-teardown
+      

--- a/integration-tests/utilities/get-credentials.js
+++ b/integration-tests/utilities/get-credentials.js
@@ -4,11 +4,12 @@ const creds = {};
 
 const getCredentials = (arn) => {
   if (!creds[arn]) {
-    const output = execSync(
-      "aws-vault exec sso-serverless-sandbox-account-admin -- " +
-        `aws sts assume-role --role-arn ${arn} --role-session-name testing`,
-      { encoding: "utf-8" },
-    );
+    let command = `aws sts assume-role --role-arn ${arn} --role-session-name testing`;
+    if (!process.env.RUNNING_IN_GITHUB_ACTION) {
+      command = `aws-vault exec sso-serverless-sandbox-account-admin -- ${command}`;
+    }
+
+    const output = execSync(command, { encoding: "utf-8" });
     const misNamedCreds = JSON.parse(output).Credentials;
     creds[arn] = {
       accessKeyId: misNamedCreds.AccessKeyId,

--- a/template.yaml
+++ b/template.yaml
@@ -254,7 +254,7 @@ Resources:
                 - 2
                 - !Split
                   - /
-                  - !Ref AWS::StackId]
+                  - !Ref AWS::StackId
 
   S3BucketPolicy:
     Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
# Notes
Run the integration tests in a github action.  I had to pass the version
between the two jobs using an output since the file gets cleared between
jobs, but is required to build the stack.  It doesn't really matter if
the version matches there since it is destroying the stack, but it wasn't
hard to make the output.  I added an [IAM user (sso link)](https://d-906757b57c.awsapps.com/start/#/console?account_id=425362996713&role_name=account-admin-8h&destination=https%3A%2F%2Fus-east-1.console.aws.amazon.com%2Fiam%2Fhome%3Fregion%3Dus-east-1%23%2Fusers%2Fdetails%2Fserverless-github-actions-user%3Fsection%3Dpermissions) with permissions to do all
of the setup and teardown, as well as to assume the integration test role.

I still kept the actual tests using a role that is defined in the test
stack so that we can manage permissions there.

Also fix an issue with the template introduced in the last change.

The workflow [takes a 6-7 minutes to run](https://github.com/DataDog/Serverless-Remote-Instrumentation/actions/runs/12776609124/usage?pr=66), which I think is fine.  It's probably pretty rare that this will finish after someone does a review of a change.  This is mostly setup and teardown, so as we add tests it will increase but not by much.  The actual tests take about 7 seconds.

# Testing
* Check out the [integration test run](https://github.com/DataDog/Serverless-Remote-Instrumentation/actions/runs/12776609124/job/35615629335?pr=66)!
* I'm still able to run the series of commands to run the same thing locally:
```
yarn integ-test-publish
aws-vault exec sso-serverless-sandbox-account-admin -- yarn run integ-test-setup
yarn integ
aws-vault exec sso-serverless-sandbox-account-admin -- yarn run integ-test-teardown
```

# Open Questions
* There is a TON of output like `adding: nodejs/node_modules/...`.  I couldn't immediately tell where it was coming from and trying to add a silent flag to the installs didn't seem to do anything.  Does anyone know offhand what is causing that?  I didn't spend a ton of time on it so if nobody knows I can try to better pinpoint it

# Next steps
* Make the config generated so that someone developing on this doesn't interfere with someone else or the github actions tests
* Read data from remote config to make better assertions about if something is instrumented correctly