### PR TITLE
Quiet logging for zipping the lambda layer

### DIFF
--- a/scripts/build_layer.sh
+++ b/scripts/build_layer.sh
@@ -27,5 +27,5 @@ mkdir -p nodejs/node_modules/datadog-remote-instrument
 
 # put src/* into node_modules/package-name/ as a package without copy src directory itself
 cp -a src/. nodejs/node_modules/datadog-remote-instrument/
-zip -r scripts/.layers/datadog_serverless_remote_instrumentation_arm64.zip nodejs
+zip -r -q scripts/.layers/datadog_serverless_remote_instrumentation_arm64.zip nodejs
 rm -rf nodejs


### PR DESCRIPTION
# Notes
Quiet log the zip file.  It logs about 40k lines when copying things from node_modules and that would drown out any log that might be important there.

# Testing
* Run where it was not quiet: https://github.com/DataDog/Serverless-Remote-Instrumentation/actions/runs/12776609124/job/35615629335
* This run where it is quiet