### PR TITLE
[SVLS-6187] Collect additional data from remote config response

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -42,3 +42,6 @@ exports.REMOTE_INSTRUMENTER_FUNCTION = "remote-instrumenter-function";
 exports.VERSION = "1.0.0";
 exports.DD_SLS_REMOTE_INSTRUMENTER_VERSION =
   "dd_sls_remote_instrumenter_version";
+
+// Remote config constants
+exports.RC_PRODUCT = "SERVERLESS_REMOTE_INSTRUMENTATION";


### PR DESCRIPTION
Context
---
This PR updates the remote instrumenter's config handling logic to:
- Grab the config ID (e.g. `39H-A1C-wZ5`) from the RC response and store it in the RcConfig object
- Grab the RC config version (e.g. `3`) from the RC response and store it in the RcConfig object

Eventually, we'll have to send these fields back to RC in subsequent requests along with the success/failure of each config application.

Testing
---
- Unit tests
- Built layer, instrumenter still runs as before, config log now looks like:
```json
{
    "0": {
        "configID": "29H-OEK-Hw5",
        "rcConfigVersion": 1,
        "configVersion": 1,
        "entityType": "lambda",
        "extensionVersion": 67,
        "nodeLayerVersion": 112,
        "pythonLayerVersion": 99,
        "priority": 1,
        "ruleFilters": [
            {
                "key": "foo",
                "values": [
                    "bar"
                ],
                "allow": false,
                "filterType": "tag"
            },
            {
                "key": "function_name",
                "values": [
                    "my-func"
                ],
                "allow": false,
                "filterType": "function_name"
            }
        ],
        "awsAccountId": "425362996713",
        "awsRegion": "ca-central-1",
        "instrumenterFunctionName": "datadog-remote-instrumenter",
        "minimumMemorySize": "512"
    },
    "eventName": "getConfigs"
}

```