### PR TITLE
[SVLS-6187] Send apply state back to RC in subsequent requests

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -71,7 +71,7 @@ exports.handler = async (event, context) => {
 
     let configs;
     try {
-      configs = await getConfigs(context);
+      configs = await getConfigs(s3Client, context);
     } catch (error) {
       // This pulls the reason from the error, just stringifying it does not return the message
       const errorDetails = JSON.parse(
@@ -95,7 +95,7 @@ exports.handler = async (event, context) => {
   else if (isScheduledInvocationEvent(event)) {
     logger.log("Received an invocation from the scheduler.");
     const errors = await listErrors(s3Client);
-    const configs = await getConfigs(context);
+    const configs = await getConfigs(s3Client, context);
     const configChanged = await configHasChanged(s3Client, configs);
     let functionsToCheck = [];
     if (configChanged) {

--- a/src/logger.js
+++ b/src/logger.js
@@ -56,11 +56,11 @@ class Logger {
   }
 
   log(message) {
-    console.log("[Datadog Remote Instrumenter]" + message);
+    console.log("[Datadog Remote Instrumenter] " + message);
   }
 
   error(message) {
-    console.error("[Datadog Remote Instrumenter]" + message);
+    console.error("[Datadog Remote Instrumenter] " + message);
   }
 }
 exports.logger = new Logger();

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -45,7 +45,7 @@ describe("handler lambda management events", () => {
       expect.anything(),
       [lambdaFunction],
     );
-    expect(config.getConfigs).toHaveBeenCalledWith(context);
+    expect(config.getConfigs).toHaveBeenCalledWith(expect.anything(), context);
     expect(instrument.instrumentFunctions).toHaveBeenCalledWith(
       expect.anything(),
       configsResult,
@@ -87,7 +87,7 @@ describe("handler lambda management events", () => {
       expect.anything(),
       [lambdaFunction],
     );
-    expect(config.getConfigs).toHaveBeenCalledWith(context);
+    expect(config.getConfigs).toHaveBeenCalledWith(expect.anything(), context);
     expect(instrument.instrumentFunctions).not.toHaveBeenCalled();
     expect(errorStorage.putError).toHaveBeenCalledWith(
       expect.anything(),


### PR DESCRIPTION
Context
---
https://github.com/DataDog/Serverless-Remote-Instrumentation/pull/73 updated the remote instrumenter to store apply state data in S3. This PR updates the API call to RC to include apply state data (ID, version, product, apply state, apply error) for each previously applied config.

See [[RFC] RCTE2 - Configuration apply status](https://docs.google.com/document/d/1bUVtEpXNTkIGvLxzkNYCxQzP2X9EK9HMBLHWXr_5KLM/edit?tab=t.0) and [[RFC] Integrating with Remote Config in a Tracer](https://docs.google.com/document/d/1u_G7TOr8wJX0dOM_zUDKuRJgxoJU_hVTd5SeaMucQUs/edit?tab=t.0) for more information about apply state. 

Testing
---
- Unit tests
- Built layer and added to remote instrumenter
  - Logs show apply state retrieval from S3
  - We now see [config apply records in REDAPL](https://dd.datad0g.com/ddsql/editor?q=SELECT%20%2A%0AFROM%20rc_client_configs%0AWHERE%20product_name%20%3D%20%27SERVERLESS_REMOTE_INSTRUMENTATION%27%0AORDER%20BY%20first_seen_at%20DESC%0ALIMIT%2010%3B)
  - [RC metrics are tagged with apply state](https://dd.datad0g.com/metric/explorer?fromUser=false&state=H4sIAAAAAAAAE12R3WrDMAyF30WXw5Rma9PhVxnFmFhOBf5JLaeQhrz7UJJ2sDvp8PnoSJ7hgYUpJ9Dwefw8maYxxwYU9MUONwb9M4NDT4nqCs1QqQYEDaC20jA9pW_at2ID9WIY0FcRp0GAShEZCyGDgoL3EbluAwrykBOj8blEW_-z93GrBE02ipdIk8R0tlrDeSydyBFroe71ZgIN9tFrnrhiPHTDeBgZy_yxwHJVIMPGYDffvfmzXq7LdRGMh0DVOIqY5E6Cv9UuJ0_9ahAoUgXdHBVwLlUulYvDAhoccgerl6zly7rCDFytcM3l69KeL9_t6dKeFWByu9Y2p10r6AvyzcTsZEsO5Cj1oGCwI6MD7W1gXBR4ChXLHvEd2TzoaV6fkIdAXGH5BWvNo8L5AQAA&start=1737657864765&end=1737661464765&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVCCc21XkyXkNkHYdOMy0zqxkQHgBdKl9dfVdQEQx1HzNtfwMQKAwEDAB9DXxtAGMlZBB1BF0cy1D4mgKMADcYZCgoADojVRwEOHScqWEYRpy0PREEPu6ODWB5bRwoPByEZC1tap00TQ10lraO0Q1ivHUh1MkRHgACACMsU+AMeXk0LEy09p5AkJAjDXkpLXSPVVSyjUmh0ejKIF2WFWMhA8gwqwQ7WUUBwME6zg0EBySQGIg6ckUyiyAygONEHXoTGUInsALQgX4EC+mEeBPyIFxSmCPD4EPu4gAwqMYCgRE40DwgA)
