### PR TITLE
Add deploy self monitoring action

### DIFF
--- a/.github/workflows/update-self-monitoring.yml
+++ b/.github/workflows/update-self-monitoring.yml
@@ -1,0 +1,33 @@
+name: Update Self Monitoring
+permissions:
+  contents: read
+  id-token: write
+env:
+  RUNNING_IN_GITHUB_ACTION: true
+  SELF_MONITORING: true
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: "ap-south-1"
+  PR_TITLE: ${{ github.event.pull_request.title }}
+
+on:
+  push:
+    branches: [prod]
+
+jobs:
+  Setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+
+      - name: Set up Node
+        uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Setup Infrastructure
+        run: yarn integ-test-setup

--- a/integration-tests/lambda-management-events.test.js
+++ b/integration-tests/lambda-management-events.test.js
@@ -1,4 +1,3 @@
-const { getCredentials } = require("./utilities/get-credentials");
 const { pollUntilTrue } = require("./utilities/poll-until-true");
 const {
   isFunctionInstrumented,
@@ -11,50 +10,33 @@ const {
   createFunction,
   deleteFunction,
 } = require("./utilities/lambda-functions");
-const { SecretsManagerClient } = require("@aws-sdk/client-secrets-manager");
-const { LambdaClient } = require("@aws-sdk/client-lambda");
-const { account, roleName, region } = require("./config.json");
-
-const arn = `arn:aws:iam::${account}:role/${roleName}`;
-
-const credentials = getCredentials(arn);
-
-const secretsManager = new SecretsManagerClient({
-  credentials,
-  region,
-});
-
-const lambdaClient = new LambdaClient({
-  credentials,
-  region,
-});
 
 describe("Remote instrumenter lambda management event tests", () => {
   const testFunction = "abcd";
 
   afterAll(async () => {
-    await deleteFunction(lambdaClient, testFunction);
-    await clearRemoteConfigs(secretsManager);
+    await deleteFunction(testFunction);
+    await clearRemoteConfigs();
   });
 
   beforeAll(async () => {
-    await deleteFunction(lambdaClient, testFunction);
-    await clearRemoteConfigs(secretsManager);
+    await deleteFunction(testFunction);
+    await clearRemoteConfigs();
   });
 
   it("can instrument a new lambda function", async () => {
     // When there is a remote config
-    await setRemoteConfig(secretsManager);
+    await setRemoteConfig();
 
     // And a lambda is created
-    await createFunction(lambdaClient, {
+    await createFunction({
       FunctionName: testFunction,
       Tags: { foo: "bar" },
     });
 
     // After some time
     const isInstrumented = await pollUntilTrue(60000, 5000, () =>
-      isFunctionInstrumented(secretsManager, lambdaClient, testFunction),
+      isFunctionInstrumented(testFunction),
     );
 
     // The function is instrumented correctly

--- a/integration-tests/utilities/aws-resources.js
+++ b/integration-tests/utilities/aws-resources.js
@@ -1,0 +1,46 @@
+const { SecretsManagerClient } = require("@aws-sdk/client-secrets-manager");
+const { LambdaClient } = require("@aws-sdk/client-lambda");
+const { account, roleName, region } = require("../config.json");
+const { S3Client } = require("@aws-sdk/client-s3");
+const { getCredentials } = require("./get-credentials");
+
+const arn = `arn:aws:iam::${account}:role/${roleName}`;
+
+let secretsManagerClient;
+const getSecretsManagerClient = async () => {
+  if (!secretsManagerClient) {
+    secretsManagerClient = new SecretsManagerClient({
+      credentials: getCredentials(arn),
+      region,
+    });
+  }
+  return secretsManagerClient;
+};
+
+exports.getSecretsManagerClient = getSecretsManagerClient;
+
+let lambdaClient;
+const getLambdaClient = async () => {
+  if (!lambdaClient) {
+    lambdaClient = new LambdaClient({
+      credentials: getCredentials(arn),
+      region,
+    });
+  }
+  return lambdaClient;
+};
+
+exports.getLambdaClient = getLambdaClient;
+
+let s3Client;
+const getS3Client = async () => {
+  if (!s3Client) {
+    s3Client = new S3Client({
+      credentials: getCredentials(arn),
+      region,
+    });
+  }
+  return s3Client;
+};
+
+exports.getS3Client = getS3Client;

--- a/integration-tests/utilities/datadog-keys.js
+++ b/integration-tests/utilities/datadog-keys.js
@@ -1,7 +1,9 @@
 const { GetSecretValueCommand } = require("@aws-sdk/client-secrets-manager");
+const { getSecretsManagerClient } = require("./aws-resources");
 
-const getSecret = async (secretsClient, name) => {
-  const response = await secretsClient.send(
+const getSecret = async (name) => {
+  const secretsManager = await getSecretsManagerClient();
+  const response = await secretsManager.send(
     new GetSecretValueCommand({
       SecretId: name,
     }),
@@ -9,14 +11,14 @@ const getSecret = async (secretsClient, name) => {
   return response.SecretString;
 };
 
-const getApiKey = async (secretsClient) => {
-  return getSecret(secretsClient, "Remote_Instrumenter_Test_API_Key");
+const getApiKey = async () => {
+  return getSecret("Remote_Instrumenter_Test_API_Key");
 };
 
 exports.getApiKey = getApiKey;
 
-const getAppKey = async (secretsClient) => {
-  return getSecret(secretsClient, "Remote_Instrumenter_Test_APPLICATION_Key");
+const getAppKey = async () => {
+  return getSecret("Remote_Instrumenter_Test_APPLICATION_Key");
 };
 
 exports.getAppKey = getAppKey;

--- a/integration-tests/utilities/is-function-instrumented.js
+++ b/integration-tests/utilities/is-function-instrumented.js
@@ -1,5 +1,6 @@
 const { GetFunctionConfigurationCommand } = require("@aws-sdk/client-lambda");
 const { getRemoteConfig } = require("./remote-config");
+const { getLambdaClient } = require("./aws-resources");
 
 const hasLayerMatching = (l, matcher, version) =>
   l?.Layers?.some(
@@ -14,13 +15,14 @@ const hasEnvVar = (l, varName) =>
 // 1. If the extension layer is configured, there is a Datadog-Extension with matching version
 // 2. If there is a language layer configured, there should is a matching version of the language layer
 // 3. It has the DD_API_KEY and DD_SITE environment variables
-const isFunctionInstrumented = async (secretsManager, lambda, functionName) => {
-  const funConfig = await lambda.send(
+const isFunctionInstrumented = async (functionName) => {
+  const lambdaClient = await getLambdaClient();
+  const funConfig = await lambdaClient.send(
     new GetFunctionConfigurationCommand({
       FunctionName: functionName,
     }),
   );
-  const rc = await getRemoteConfig(secretsManager);
+  const rc = await getRemoteConfig();
   const { extension_version, node_layer_version, python_layer_version } =
     rc.data[0].attributes.instrumentation_settings;
 

--- a/integration-tests/utilities/lambda-functions.js
+++ b/integration-tests/utilities/lambda-functions.js
@@ -6,8 +6,9 @@ const {
   Runtime,
 } = require("@aws-sdk/client-lambda");
 const { account, testLambdaRole } = require("../config.json");
+const { getLambdaClient } = require("./aws-resources");
 
-const createFunction = async (lambdaClient, lambdaProps) => {
+const createFunction = async (lambdaProps) => {
   const zip = new JSZip();
   zip.file(
     "index.js",
@@ -28,14 +29,16 @@ const createFunction = async (lambdaClient, lambdaProps) => {
     ...lambdaProps,
   });
 
+  const lambdaClient = await getLambdaClient();
   await lambdaClient.send(command);
 };
 
 exports.createFunction = createFunction;
 
-const deleteFunction = async (lambdaClient, functionName) => {
+const deleteFunction = async (functionName) => {
   const command = new DeleteFunctionCommand({ FunctionName: functionName });
   try {
+    const lambdaClient = await getLambdaClient();
     await lambdaClient.send(command);
     return true;
   } catch (e) {

--- a/integration-tests/utilities/remote-config.js
+++ b/integration-tests/utilities/remote-config.js
@@ -2,11 +2,8 @@ const axios = require("axios");
 const { account, region } = require("../config.json");
 const { getApiKey, getAppKey } = require("./datadog-keys");
 
-const getRemoteConfig = async (secretsClient) => {
-  const [apiKey, appKey] = await Promise.all([
-    getApiKey(secretsClient),
-    getAppKey(secretsClient),
-  ]);
+const getRemoteConfig = async () => {
+  const [apiKey, appKey] = await Promise.all([getApiKey(), getAppKey()]);
 
   const url =
     "https://datad0g.com/api/unstable/remote_config/products/serverless_remote_instrumentation/config?filter%5Baws_account_id%5D={AWS_ACCOUNT_SLOT}&filter%5Bregion%5D={REGION_SLOT}"
@@ -24,11 +21,8 @@ const getRemoteConfig = async (secretsClient) => {
 
 exports.getRemoteConfig = getRemoteConfig;
 
-const setRemoteConfig = async (secretsClient) => {
-  const [apiKey, appKey] = await Promise.all([
-    getApiKey(secretsClient),
-    getAppKey(secretsClient),
-  ]);
+const setRemoteConfig = async () => {
+  const [apiKey, appKey] = await Promise.all([getApiKey(), getAppKey()]);
 
   const rc = {
     data: {
@@ -75,11 +69,8 @@ const setRemoteConfig = async (secretsClient) => {
 
 exports.setRemoteConfig = setRemoteConfig;
 
-const deleteRemoteConfig = async (secretsClient, id) => {
-  const [apiKey, appKey] = await Promise.all([
-    getApiKey(secretsClient),
-    getAppKey(secretsClient),
-  ]);
+const deleteRemoteConfig = async (id) => {
+  const [apiKey, appKey] = await Promise.all([getApiKey(), getAppKey()]);
 
   const url = `https://datad0g.com/api/unstable/remote_config/products/serverless_remote_instrumentation/config/${id}`;
 
@@ -93,10 +84,10 @@ const deleteRemoteConfig = async (secretsClient, id) => {
 
 exports.deleteRemoteConfig = deleteRemoteConfig;
 
-const clearRemoteConfigs = async (secretsClient) => {
-  const rcs = await getRemoteConfig(secretsClient);
+const clearRemoteConfigs = async () => {
+  const rcs = await getRemoteConfig();
   const ids = rcs.data.map((item) => item.id);
-  const results = ids.map((id) => deleteRemoteConfig(secretsClient, id));
+  const results = ids.map((id) => deleteRemoteConfig(id));
   await Promise.all(results);
 };
 

--- a/integration-tests/utilities/remote-instrumenter-invocations.js
+++ b/integration-tests/utilities/remote-instrumenter-invocations.js
@@ -1,16 +1,15 @@
 const { InvokeCommand } = require("@aws-sdk/client-lambda");
+const { getLambdaClient } = require("./aws-resources");
 
-const invokeLambdaWithScheduledEvent = async (
-  lambda,
-  remoteInstrumenterName,
-) => {
+const invokeLambdaWithScheduledEvent = async (remoteInstrumenterName) => {
   const command = new InvokeCommand({
     FunctionName: remoteInstrumenterName,
     Payload: JSON.stringify({
       "event-type": "Scheduled Instrumenter Invocation",
     }),
   });
-  const { Payload } = await lambda.send(command);
+  const lambdaClient = await getLambdaClient();
+  const { Payload } = lambdaClient.send(command);
   return JSON.parse(Buffer.from(Payload).toString());
 };
 

--- a/scripts/test_setup.js
+++ b/scripts/test_setup.js
@@ -15,9 +15,16 @@ const generateTestConfig = () => {
 
     if (process.env.USER) {
       namingSeed = process.env.USER;
-    } else if (process.env.RUNNING_IN_GITHUB_ACTION) {
-      namingSeed = process.env.PR_TITLE;
-      region = "eu-south-1";
+    }
+
+    if (process.env.RUNNING_IN_GITHUB_ACTION) {
+      if (process.env.SELF_MONITORING) {
+        namingSeed = "self-monitoring";
+        region = "ap-south-1";
+      } else {
+        namingSeed = process.env.PR_TITLE;
+        region = "eu-south-1";
+      }
     }
     // Remove any non alphanumeric characters to fit stack name constraints
     namingSeed = namingSeed.replace(/[\W_]+/g, "");
@@ -32,6 +39,12 @@ const generateTestConfig = () => {
       roleName: `remote-instrumenter-testing-${region}-${namingSeed}`,
       trailName: `datadog-serverless-instrumentation-trail-testing-${namingSeed}`,
     };
+
+    // There is a 64 character limit for a lot of resources
+    Object.entries(config).forEach(
+      ([key, val]) => (config[key] = val.slice(0, 63).toLowerCase()),
+    );
+
     writeFileSync(configPath, JSON.stringify(config, null, 2));
   }
   return config;


### PR DESCRIPTION
# Notes
Add the deploy self monitoring action to update our self monitoring stack when a commit is pushed to prod.  This will keep the self monitor stack up to date so we can continually run tests against it asynchronously.  To do this I had to pick a region just for self monitoring, ap-south-1.  I picked this kind of at random, if there are regions we prefer / don't prefer then just let me know and it's easy enough to change.

Also included in this is some changes to make writing tests a bit easier by putting the clients in getter functions to cache them and so that the tests themselves don't need to initialize a client.

Also fix the integration test run on the github action to use a separate set of infrastructure, the conditions were not correct before.

# Testing
* In a previous iteration of this PR the branch selector also included this one, here is a successful setup for the [self monitoring setup action](https://github.com/DataDog/Serverless-Remote-Instrumentation/actions/runs/12951255169/job/36125892087?pr=75) / [another instance](https://github.com/DataDog/Serverless-Remote-Instrumentation/actions/runs/12951332434/job/36129112535)

# Next steps
1. Write a github action to run the integration tests every 30 minutes or so against the self monitoring stack
2. Write more integration tests to cover the cases we think are important