### PR TITLE
[SVLS] Remove remote instrumentation when no configs are received

### DIFF
--- a/src/apply-state.js
+++ b/src/apply-state.js
@@ -2,6 +2,7 @@ const {
   GetObjectCommand,
   PutObjectCommand,
   NoSuchKey,
+  DeleteObjectCommand,
 } = require("@aws-sdk/client-s3");
 const {
   FAILED,
@@ -44,6 +45,23 @@ async function putApplyState(client, applyStateObjects) {
   );
 }
 exports.putApplyState = putApplyState;
+
+async function deleteApplyState(client) {
+  const bucketName = process.env.DD_S3_BUCKET;
+  try {
+    await client.send(
+      new DeleteObjectCommand({
+        Bucket: bucketName,
+        Key: APPLY_STATE_KEY,
+      }),
+    );
+  } catch (caught) {
+    if (caught instanceof NoSuchKey) {
+      return;
+    }
+  }
+}
+exports.deleteApplyState = deleteApplyState;
 
 function createApplyStateObject(instrumentOutcome, config) {
   const failedFunctions = [

--- a/src/functions.js
+++ b/src/functions.js
@@ -231,6 +231,7 @@ function isRemotelyInstrumented(lambdaFunc) {
   );
   return tagKeys.has(DD_SLS_REMOTE_INSTRUMENTER_VERSION);
 }
+exports.isRemotelyInstrumented = isRemotelyInstrumented;
 
 function isCorrectlyInstrumented(layers, config, targetLambdaRuntime) {
   // Check if the extension is correct


### PR DESCRIPTION
Context
---
Currently, when the remote instrumenter receives no configs from RC, it no-ops. Instead, it should treat "no configs" as "clear remote instrumentation". 

This PR updates the remote instrumenter behavior on "no configs" to:
- Remove instrumentation from remotely instrumented functions
- Untag remotely instrumented functions of the remotely instrumented tag
- Delete the apply state file from s3

Testing
---
- Unit tests
- Built layer and applied to remote instrumenter
  - Deleted all configs for the region
  - Saw remotely instrumented functions get uninstrumented and untagged
  - Saw apply state file get deleted