### PR TITLE
Add self monitoring test workflow

### DIFF
--- a/.github/workflows/self-monitoring-tests.yml
+++ b/.github/workflows/self-monitoring-tests.yml
@@ -1,0 +1,35 @@
+name: Run Self Monitoring
+permissions:
+  contents: read
+  id-token: write
+env:
+  RUNNING_IN_GITHUB_ACTION: true
+  SELF_MONITORING: true
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: "ap-south-1"
+
+on:
+  schedule:
+    - cron: "0,30 * * * *"
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+
+      - name: Set up Node
+        uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Setup Config
+        run: node -e "require('./scripts/test_setup').generateTestConfig()"
+
+      - name: Tests
+        run: yarn integ


### PR DESCRIPTION
# Notes
Add the self monitoring test workflow.  This is currently set to run every half hour on the hour and 30 minute marks.  This can be adjusted as we feel necessary.

# Testing
* Initially this PR had the action run on pushes to this branch as well, see a [test run here](https://github.com/DataDog/Serverless-Remote-Instrumentation/actions/runs/12955110292/job/36138541734)
* See the [action history here](https://github.com/DataDog/Serverless-Remote-Instrumentation/actions/workflows/self-monitoring-tests.yml).  I'm not sure that just being part of this PR will make it run on that cadence, but it will appear here after merge

# Next Steps
1. Write tests to cover cases we care about