### PR TITLE
Don't instrument manually instrumented functions

### DIFF
--- a/integration-tests/scheduled-events.test.js
+++ b/integration-tests/scheduled-events.test.js
@@ -48,6 +48,29 @@ describe("Remote instrumenter scheduled event tests", () => {
     expect(isUninstrumented).toStrictEqual(true);
   });
 
+  it("manually instrumented function does NOT get instrumented", async () => {
+    await setRemoteConfig();
+    await createFunction({
+      FunctionName: testFunction,
+      Tags: { foo: "bar" },
+      Environment: {
+        Variables: {
+          DD_API_KEY: "a",
+          DD_SITE: "b",
+        },
+      },
+    });
+
+    const res = await invokeLambdaWithScheduledEvent();
+
+    expect(Object.keys(res.instrument.skipped)).toEqual(
+      expect.arrayContaining([testFunction]),
+    );
+    expect(res.instrument.skipped[testFunction].reasonCode).toStrictEqual(
+      "already-manually-instrumented",
+    );
+  });
+
   it("function with correct tags does get instrumented", async () => {
     await createFunction({
       FunctionName: testFunction,

--- a/src/consts.js
+++ b/src/consts.js
@@ -36,12 +36,15 @@ exports.ALREADY_CORRECT_EXTENSION_AND_LAYER =
   "already-correct-extension-and-layer";
 exports.UNSUPPORTED_RUNTIME = "unsupported-runtime";
 exports.NOT_SATISFYING_TARGETING_RULES = "not-satisfying-targeting-rules";
+exports.ALREADY_MANUALLY_INSTRUMENTED = "already-manually-instrumented";
 exports.REMOTE_INSTRUMENTER_FUNCTION = "remote-instrumenter-function";
 
 // Remote instrumentation tag values
 exports.VERSION = "1.0.0";
 exports.DD_SLS_REMOTE_INSTRUMENTER_VERSION =
   "dd_sls_remote_instrumenter_version";
+exports.DD_API_KEY = "DD_API_KEY";
+exports.DD_SITE = "DD_SITE";
 
 // Remote config constants
 exports.RC_PRODUCT = "SERVERLESS_REMOTE_INSTRUMENTATION";


### PR DESCRIPTION
# Notes
If a function has already been manually instrumented with something like CDK or the serverless plugin, don't try to re instrument it.

One note from the JIRA
> We need to make sure this doesn’t break the lambda management event handling. Initial concern to verify:
> 
> * A user redeploys their function that’s using remote instrumentation using a tool like serverless plugin
> 
> * Does the remote instrumentation tag get wiped?
>
> * If so, their instrumentation won’t get fixed

I tested this out using the serverless framework.  What I tried was
1. Deploy the serverless framework using a tag
2. Manually add a tag to the function
3. Change the tags on the function in the serverless definition
4. Deploy the serverless framework again

The result was the tag that was manually added was removed from the lambda function.  I don't believe there is a difference from the perspective of deploying the change if the tag was added by me or the remote instrumenter, so when a remotely instrumented function is manually instrumented the tags added by the remote instrumenter will be removed, and then it will be ignored in future iterations.  Since serverless uses cloudformation to deploy, it should also be the case for any cloudformation based deployment like CDK.

# Testing
* Unit / integration tests



# Documentation
JIRA: https://datadoghq.atlassian.net/browse/SVLS-6196