### PR TITLE
Skip error events

### DIFF
--- a/src/lambda-event.js
+++ b/src/lambda-event.js
@@ -104,6 +104,14 @@ function shouldSkipEvent(event) {
     );
     return true;
   }
+
+  if (event?.detail?.errorCode) {
+    logger.log(
+      `Skipping '${event.detail.eventName}' event because the lambda update failed: ${event?.detail?.errorCode}: ${event?.detail?.errorMessage}.`,
+    );
+    return true;
+  }
+
   return false;
 }
 exports.shouldSkipEvent = shouldSkipEvent;

--- a/test/lambda-event.test.js
+++ b/test/lambda-event.test.js
@@ -231,4 +231,14 @@ describe("shouldSkipEvent", () => {
     };
     expect(shouldSkipEvent(event)).toBe(false);
   });
+  it("should return true for events that did not succeed", () => {
+    const event = {
+      detail: {
+        eventName: "UntagResource20170331v2",
+        errorCode: "DidNotWork!",
+        errorMessage: "SomethingBadHappened",
+      },
+    };
+    expect(shouldSkipEvent(event)).toBe(true);
+  });
 });


### PR DESCRIPTION
# Notes
When a lambda management event comes in check if it was caused by an error when deciding to skip it or not.  Theses kind of events include things like 400 errors when trying to update a lambda, and mean that no change was applied. Since no change was applied to the lambda, we won't have to update anything. I noticed this because it was causing an error because there is no response element section of the event, and we depend on that for update events to get the function name.

# Testing
I noticed in [this log statement](https://d-906757b57c.awsapps.com/start/#/console?account_id=425362996713&role_name=account-admin-8h&destination=https%3A%2F%2Feu-north-1.console.aws.amazon.com%2Fcloudwatch%2Fhome%3Fregion%3Deu-north-1%23logsV2%3Alog-groups%2Flog-group%2F%24252Faws%24252Flambda%24252Fremote-instrumenter-testing-alexangelillo%2Flog-events%2F2025%24252F01%24252F29%24252F%24255B%242524LATEST%24255Db73f737657664b90a0123a45b0d13482%243Fstart%243D1738159863993%2426refEventId%243D38762260243450610225091631125309254561096096429420183555) that the remote instrumenter lambda errors sometimes.  Here is a section of the request that caused the error

```
{
    "detail-type": "AWS API Call via CloudTrail",
    "source": "aws.lambda",
    "detail": {
        "errorCode": "ResourceConflictException",
        "errorMessage": "The operation cannot be performed at this time. An update is in progress for resource: arn:aws:lambda:eu-north-1:425362996713:function:lambdaManagementEventTest",
        "requestParameters": {
            "functionName": "arn:aws:lambda:eu-north-1:425362996713:function:lambdaManagementEventTest",
            "handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
            "environment": {},
            "layers": [
                "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension:67",
                "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node20-x:112"
            ]
        },
        "responseElements": null,
        ...
    }
}
...
2025-01-29T14:11:04.093Z	8eb01781-7ac7-48f6-b383-d5fa023c499b	ERROR	Invoke Error 	
{
    "errorType": "TypeError",
    "errorMessage": "Cannot read properties of null (reading 'functionName')",
    "stack": [
        "TypeError: Cannot read properties of null (reading 'functionName')",
        "    at getFunctionFromLambdaEvent (/opt/nodejs/node_modules/datadog-remote-instrument/lambda-event.js:123:50)",
        "    at exports.handler (/opt/nodejs/node_modules/datadog-remote-instrument/handler.js:69:37)",
        "    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29)"
    ]
}
```

Which is [this line](https://github.com/DataDog/Serverless-Remote-Instrumentation/blob/prod/src/lambda-event.js#L121)

```
functionName = event.detail.responseElements.functionName;
```

Which happens because there is no responseElements section because of the error.