### PR TITLE
Handle target function not existing

### DIFF
--- a/integration-tests/lambda-management-events.test.js
+++ b/integration-tests/lambda-management-events.test.js
@@ -14,6 +14,7 @@ const {
 } = require("./utilities/lambda-functions");
 const {
   invokeLambdaWithScheduledEvent,
+  invokeLambdaWithLambdaManagementEvent,
 } = require("./utilities/remote-instrumenter-invocations");
 
 describe("Remote instrumenter lambda management event tests", () => {
@@ -72,5 +73,12 @@ describe("Remote instrumenter lambda management event tests", () => {
 
     // The function is instrumented correctly
     expect(isInstrumented).toStrictEqual(true);
+  });
+
+  it("doesn't error on nonexistant function", async () => {
+    const { errors } = await invokeLambdaWithLambdaManagementEvent({
+      targetFunctionName: "LambdaEventThisDoesNotExist",
+    });
+    expect(errors).toBeFalsy();
   });
 });

--- a/integration-tests/scheduled-events.test.js
+++ b/integration-tests/scheduled-events.test.js
@@ -15,12 +15,19 @@ const {
   deleteFunction,
 } = require("./utilities/lambda-functions");
 const { Runtime } = require("@aws-sdk/client-lambda");
+const {
+  deleteErrorObject,
+  putErrorObject,
+  doesErrorObjectExist,
+} = require("./utilities/s3-error-object");
 
 describe("Remote instrumenter scheduled event tests", () => {
   const testFunction = "scheduledEventTest";
+  const functionThatDoesntExist = "ThisDoesNotExist";
 
   afterAll(async () => {
     await deleteFunction(testFunction);
+    await deleteErrorObject(functionThatDoesntExist);
     await clearRemoteConfigs();
   });
 
@@ -174,5 +181,22 @@ describe("Remote instrumenter scheduled event tests", () => {
       isFunctionUninstrumented(testFunction),
     );
     expect(isUninstrumented).toStrictEqual(true);
+  });
+
+  it("error for nonexistant function gets cleared and skipped", async () => {
+    await putErrorObject(functionThatDoesntExist);
+
+    const res = await invokeLambdaWithScheduledEvent();
+
+    if (Object.keys(res.instrument.skipped).includes(functionThatDoesntExist)) {
+      expect(
+        res.instrument.skipped[functionThatDoesntExist].reasonCode,
+      ).toStrictEqual("function-not-found");
+    }
+
+    const doesErrorObjectStillExist = await doesErrorObjectExist(
+      functionThatDoesntExist,
+    );
+    expect(doesErrorObjectStillExist).toEqual(false);
   });
 });

--- a/integration-tests/utilities/remote-instrumenter-invocations.js
+++ b/integration-tests/utilities/remote-instrumenter-invocations.js
@@ -16,3 +16,36 @@ const invokeLambdaWithScheduledEvent = async () => {
 };
 
 exports.invokeLambdaWithScheduledEvent = invokeLambdaWithScheduledEvent;
+
+const invokeLambdaWithLambdaManagementEvent = async ({
+  eventName = "UpdateFunctionConfiguration20150331v2",
+  targetFunctionName,
+}) => {
+  const command = new InvokeCommand({
+    FunctionName: functionName,
+    Payload: JSON.stringify({
+      "detail-type": "AWS API Call via CloudTrail",
+      detail: {
+        eventName,
+        requestParameters: {
+          functionName: targetFunctionName,
+        },
+        responseElements: {
+          functionName: targetFunctionName,
+        },
+      },
+      source: "aws.lambda",
+      name: `integration-tests${process.env.USER}`,
+    }),
+  });
+  const lambdaClient = await getLambdaClient();
+  const res = await lambdaClient.send(command);
+  const payload = JSON.parse(Buffer.from(res.Payload).toString());
+  return {
+    payload,
+    errors: res.FunctionError,
+  };
+};
+
+exports.invokeLambdaWithLambdaManagementEvent =
+  invokeLambdaWithLambdaManagementEvent;

--- a/src/consts.js
+++ b/src/consts.js
@@ -38,6 +38,7 @@ exports.UNSUPPORTED_RUNTIME = "unsupported-runtime";
 exports.NOT_SATISFYING_TARGETING_RULES = "not-satisfying-targeting-rules";
 exports.ALREADY_MANUALLY_INSTRUMENTED = "already-manually-instrumented";
 exports.REMOTE_INSTRUMENTER_FUNCTION = "remote-instrumenter-function";
+exports.FUNCTION_NOT_FOUND = "function-not-found";
 
 // Remote instrumentation tag values
 exports.VERSION = "1.0.0";


### PR DESCRIPTION
# Notes
Handle the target function not existing, both in scheduled events and lambda management events.  This can happen in a lambda management event if someone creates / deletes a lambda before we process the event, which is probably rare in practice but happens frequently during integration testing.  Also handle this on scheduled events, where I noticed that the instrumenter wouldn't clear the errors for the config changed events.





# Testing
* Integration / unit tests
* I don't see the same errors that weren't part of a test after deploying this.  The graphs below seem to back this up.

See this graph of lambda errors before this change
![image](https://github.com/user-attachments/assets/8d7d5e42-1a17-4e1a-a6d7-0fd73309939c)

See this graph of errors after, note the difference in the Y axis values (23->3).
![image](https://github.com/user-attachments/assets/562ea648-da7e-4697-bb04-baaab5de9c9b)


The remaining errors all seem to be 500s from getting the remote config
```
2025-01-30T16:20:39.928Z	5b515147-ccde-4a82-9607-c849cfefe35e	INFO	[Datadog Remote Instrumenter] AxiosError: Request failed with status code 500 |
```