### PR TITLE
Update is instrumented logic

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -45,6 +45,8 @@ exports.VERSION = "1.0.0";
 exports.DD_SLS_REMOTE_INSTRUMENTER_VERSION =
   "dd_sls_remote_instrumenter_version";
 exports.DD_API_KEY = "DD_API_KEY";
+exports.DD_KMS_API_KEY = "DD_KMS_API_KEY";
+exports.DD_API_KEY_SECRET_ARN = "DD_API_KEY_SECRET_ARN";
 exports.DD_SITE = "DD_SITE";
 
 // Remote config constants


### PR DESCRIPTION
# Notes
Update the logic of the is instrumented check to see if a function has datadog layers as well.  This could be the case where a customer has the layers setup but the environment variables are not because they are defined in the datadog.yaml file.

Also remove a case where the function was instrumented, but not remotely instrumented, and we would apply the RC tags to it.
