### PR TITLE
Fix format script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=20.0.0 <21.0.0"
   },
   "scripts": {
-    "format": "eslint --fix . self-monitoring-app/modifier_handler.js",
+    "format": "eslint --fix .",
     "lint": "eslint -c eslint.config.mjs . ",
     "lint-yaml": "eslint -c eslint.config.yaml.mjs . ",
     "format-yaml": "eslint --fix -c eslint.config.yaml.mjs . ",


### PR DESCRIPTION
# Notes
I previously removed the self monitoring directory but didn't notice that yarn format explicitly uses that when running.  Remove that from the format script since it doesn't exist anymore.

Error:
```
> yarn format
Oops! Something went wrong! :(

ESLint: 8.57.1

No files matching the pattern "self-monitoring-app/modifier_handler.js" were found. Please check for typing mistakes in the pattern.
```

# Testing
* `yarn format` failed before this and works now.  I don't really want to put this into something that runs on PR because I don't think code should be modified as it is in the release / commit process and lint is already run, but changing directories like this should be pretty uncommon (and `.` should cover everything anyway)