### PR TITLE
Store and delete specific RCs by ID

### DIFF
--- a/integration-tests/lambda-management-events.test.js
+++ b/integration-tests/lambda-management-events.test.js
@@ -5,6 +5,7 @@ const {
 } = require("./utilities/is-function-instrumented");
 const {
   setRemoteConfig,
+  clearKnownRemoteConfigs,
   clearRemoteConfigs,
 } = require("./utilities/remote-config");
 const { namingSeed } = require("./config.json");
@@ -26,9 +27,13 @@ describe("Remote instrumenter lambda management event tests", () => {
     await clearRemoteConfigs();
   });
 
+  beforeAll(async () => {
+    await clearRemoteConfigs();
+  });
+
   beforeEach(async () => {
     await deleteFunction(testFunction);
-    await clearRemoteConfigs();
+    await clearKnownRemoteConfigs();
   });
 
   it("can instrument a new lambda function", async () => {

--- a/integration-tests/scheduled-events.test.js
+++ b/integration-tests/scheduled-events.test.js
@@ -6,6 +6,7 @@ const {
 const { namingSeed } = require("./config.json");
 const {
   setRemoteConfig,
+  clearKnownRemoteConfigs,
   clearRemoteConfigs,
 } = require("./utilities/remote-config");
 const {
@@ -34,6 +35,10 @@ describe("Remote instrumenter scheduled event tests", () => {
 
   beforeEach(async () => {
     await deleteFunction(testFunction);
+    await clearKnownRemoteConfigs();
+  });
+
+  beforeAll(async () => {
     await clearRemoteConfigs();
   });
 


### PR DESCRIPTION
# Notes
Store the ID of a remote config we see when we get / set them.  Then between tests we can delete the ones that are known, since there aren't likely to be other RCs made in that span.  We still need to clear it fully beforehand and afterwards though.

This will cause the tests to do fewer calls to RC.  I noticed that sometimes the self monitoring tests failed because they were throttled, so this will hopefully help with that.  It should reduce it by number of tests - 1 calls.

# Testing
* This is a test only change, and the tests still pass.
* This actually causes failures quite frequently in the self monitoring, in the last 1 week
![image](https://github.com/user-attachments/assets/0a84b95a-70a3-4337-9191-fadbc54b77e7)

Insights info:
Log group
```
/aws/lambda/remote-instrumenter-testing-selfmonitoring
```

Query

```
fields @timestamp, @message, @logStream, @log
| filter @message like /bypass/
| stats count() by bin(1h)
```

Hopefully after release we will see a decrease in this