### PR TITLE
Handle stack creation events

### DIFF
--- a/integration-tests/utilities/remote-instrumenter-invocations.js
+++ b/integration-tests/utilities/remote-instrumenter-invocations.js
@@ -51,12 +51,12 @@ const invokeLambdaWithLambdaManagementEvent = async ({
 exports.invokeLambdaWithLambdaManagementEvent =
   invokeLambdaWithLambdaManagementEvent;
 
-const invokeLambdaWithCFNDeleteEvent = async () => {
+const invokeLambdaWithCFNEvent = async (eventType) => {
   const s3Key = `cloudformationDelete/${new Date()}`;
   const command = new InvokeCommand({
     FunctionName: functionName,
     Payload: JSON.stringify({
-      RequestType: "Delete",
+      RequestType: eventType,
       ResponseURL: await createPresignedUrl(s3Key),
       ResourceType: "AWS::CloudFormation::CustomResource",
       StackId: "fakeStackId",
@@ -75,4 +75,14 @@ const invokeLambdaWithCFNDeleteEvent = async () => {
   };
 };
 
+const invokeLambdaWithCFNDeleteEvent = async () => {
+  return invokeLambdaWithCFNEvent("Delete");
+};
+
 exports.invokeLambdaWithCFNDeleteEvent = invokeLambdaWithCFNDeleteEvent;
+
+const invokeLambdaWithCFNCreateEvent = async () => {
+  return invokeLambdaWithCFNEvent("Create");
+};
+
+exports.invokeLambdaWithCFNCreateEvent = invokeLambdaWithCFNCreateEvent;

--- a/src/consts.js
+++ b/src/consts.js
@@ -8,6 +8,7 @@ exports.SUPPORTED_RUNTIMES = [NODE, PYTHON];
 // Event Types
 exports.LAMBDA_EVENT = "LambdaEvent";
 exports.SCHEDULED_INVOCATION_EVENT = "ScheduledInvocationEvent";
+exports.CLOUDFORMATION_CREATE_EVENT = "CloudformationCreateEvent";
 exports.CLOUDFORMATION_DELETE_EVENT = "CloudformationDeleteEvent";
 
 // Config Enums


### PR DESCRIPTION
# Notes
When the stack is created, instrument the functions in that region just like for a scheduled invocation event.  If anything fails just stop and report success back to CFN since we don't want to fail stack creation because of a problem instrumenting a function.

# Testing
* Unit / integration tests
* I'm planning on adding another lambda to the infrastructure stack so there is one there when the remote instrumenter gets setup, but that turns out to be slightly more involved so I'm separating it into a different PR


# Documentation
JIRA: https://datadoghq.atlassian.net/browse/SVLS-6259