### PR TITLE
Skip events from the remote instrumenter

### DIFF
--- a/src/lambda-event.js
+++ b/src/lambda-event.js
@@ -114,6 +114,15 @@ function shouldSkipEvent(event) {
     return true;
   }
 
+  if (
+    event?.detail?.userIdentity?.principalId.includes(instrumenterFunctionName)
+  ) {
+    logger.log(
+      `Skipping '${event.detail.eventName}' event because its source is the remote instrumenter.`,
+    );
+    return true;
+  }
+
   return false;
 }
 exports.shouldSkipEvent = shouldSkipEvent;

--- a/test/lambda-event.test.js
+++ b/test/lambda-event.test.js
@@ -241,4 +241,28 @@ describe("shouldSkipEvent", () => {
     };
     expect(shouldSkipEvent(event)).toBe(true);
   });
+  it("should return true for events that originate from the remote instrumenter", () => {
+    const event = {
+      detail: {
+        eventName: "UpdateFunctionConfiguration20150331v2",
+        userIdentity: {
+          principalId: "CanonicalID:instrumenter-function-name",
+        },
+      },
+    };
+    process.env.DD_INSTRUMENTER_FUNCTION_NAME = "instrumenter-function-name";
+    expect(shouldSkipEvent(event)).toBe(true);
+  });
+  it("should return false for events that originate from other sources", () => {
+    const event = {
+      detail: {
+        eventName: "UpdateFunctionConfiguration20150331v2",
+        userIdentity: {
+          principalId: "CanonicalID:something-else",
+        },
+      },
+    };
+    process.env.DD_INSTRUMENTER_FUNCTION_NAME = "instrumenter-function-name";
+    expect(shouldSkipEvent(event)).toBe(false);
+  });
 });


### PR DESCRIPTION
# Notes
Skip update events that originate from the remote instrumenter.  Previously the instrumenter would instrument a function and trigger an update event, causing the instrumenter to run again.  Without this check, the instrumenter would get the remote config and do all the work to check if the function needs to be instrumented or not, and decide to skip the function because it is already instrumented.  With this the event is just skipped.

# Testing
* Check out [these logs](https://eu-north-1.console.aws.amazon.com/cloudwatch/home?region=eu-north-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fremote-instrumenter-testing-alexangelillo/log-events/2025$252F02$252F10$252F$255B$2524LATEST$255De8613d509d544068bdb78f0cb4162aa7$3Fstart$3D1739212122862$26refEventId$3D38785726400371073239061680830112838412897008967906230275) that are in the instrumenter log group.  [Sign in link](https://d-906757b57c.awsapps.com/start/#/console?account_id=425362996713&role_name=account-admin-8h) for the sandbox account