### PR TITLE
Wait before trying to instrument

### DIFF
--- a/src/aws-resources.js
+++ b/src/aws-resources.js
@@ -1,0 +1,13 @@
+const { LambdaClient } = require("@aws-sdk/client-lambda");
+
+let lambdaClient;
+const getLambdaClient = () => {
+  if (!lambdaClient) {
+    lambdaClient = new LambdaClient({
+      region: process.env.AWS_REGION,
+    });
+  }
+  return lambdaClient;
+};
+
+exports.getLambdaClient = getLambdaClient;

--- a/src/handler.js
+++ b/src/handler.js
@@ -14,10 +14,7 @@ const {
   putError,
   listErrors,
 } = require("./error-storage");
-const {
-  LambdaClient,
-  ResourceNotFoundException,
-} = require("@aws-sdk/client-lambda");
+const { ResourceNotFoundException } = require("@aws-sdk/client-lambda");
 const {
   ResourceGroupsTaggingAPIClient,
 } = require("@aws-sdk/client-resource-groups-tagging-api");
@@ -27,6 +24,7 @@ const {
   getAllFunctions,
   enrichFunctionsWithTags,
 } = require("./functions");
+const { getLambdaClient } = require("./aws-resources");
 const { instrumentFunctions } = require("./instrument");
 const {
   LAMBDA_EVENT,
@@ -39,9 +37,7 @@ const {
 } = require("./consts");
 
 const awsRegion = process.env.AWS_REGION;
-const lambdaClient = new LambdaClient({
-  region: awsRegion,
-});
+const lambdaClient = getLambdaClient();
 const taggingClient = new ResourceGroupsTaggingAPIClient({
   region: awsRegion,
 });

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -14,6 +14,7 @@ const { logger } = require("./logger");
 const {
   filterFunctionsToChangeInstrumentation,
   isRemotelyInstrumented,
+  waitUntilFunctionIsActive,
 } = require("./functions");
 const { tagResourcesWithSlsTag, untagResourcesOfSlsTag } = require("./tag");
 const {
@@ -70,6 +71,8 @@ async function instrumentWithDatadogCi(
   } else {
     command.push("-r", config.awsRegion);
   }
+
+  await waitUntilFunctionIsActive(functionName);
 
   logger.logInstrumentOutcome({
     ddSlsEventName: operationName,

--- a/src/sleep.js
+++ b/src/sleep.js
@@ -1,0 +1,3 @@
+const sleep = async (ms) => new Promise((res) => setTimeout(res, ms));
+
+exports.sleep = sleep;

--- a/template.yaml
+++ b/template.yaml
@@ -163,6 +163,7 @@ Resources:
             Action:
               - lambda:InvokeFunction
               - lambda:GetFunction
+              - lambda:GetFunctionConfiguration
               - lambda:UpdateFunctionConfiguration
               - lambda:TagResource
               - lambda:UntagResource

--- a/test/instrument.test.js
+++ b/test/instrument.test.js
@@ -18,6 +18,11 @@ const {
   LAMBDA_EVENT,
 } = require("../src/consts");
 
+jest.mock("../src/functions", () => ({
+  ...jest.requireActual("../src/functions"),
+  waitUntilFunctionIsActive: jest.fn(),
+}));
+
 describe("getExtensionAndRuntimeLayerVersion", () => {
   it("should return the layer and runtime version for node", () => {
     const runtime = "nodejs12.x";


### PR DESCRIPTION
# Notes
Sometimes a lambda will be updated and trigger the remote instrumenter to run before the lambda exits the pending state.

I noticed this happening occasionally in the remote instrumenter self monitoring, and hopefully this change makes that less frequent.

I also created a function to make a lambda client and let us get it from where ever we need it to avoid having to pass it around everywhere.  It's mostly a preference thing, so if we want to keep it passed in here I can switch that.

# Testing
* The tests still pass, I'm hoping to see fewer instances of `ResourceConflictException`s in self monitoring after this change

## Insights
Log Group: `/aws/lambda/remote-instrumenter-testing-selfmonitoring`

Query:
```
fields @timestamp, @message, @logStream, @log
| filter @message like /ResourceConflictException/
| stats count() by bin(1h)
```

![image](https://github.com/user-attachments/assets/2707c9c7-aa4a-4cbc-baf5-f4403c1321cd)
