### PR TITLE
Generate lambda function names for tests

### DIFF
--- a/integration-tests/utilities/remote-config.js
+++ b/integration-tests/utilities/remote-config.js
@@ -111,13 +111,16 @@ const deleteRemoteConfig = async (id) => {
 
 exports.deleteRemoteConfig = deleteRemoteConfig;
 
-const clearRemoteConfigs = async () => {
+const clearRemoteConfigs = async (waitForEventualConsistency = false) => {
   const rcs = await getRemoteConfig();
   const ids = rcs.data.map((item) => item.id);
   const results = ids.map((id) => deleteRemoteConfig(id));
   await Promise.all(results);
   while (remoteConfigIds.length) {
     remoteConfigIds.pop();
+  }
+  if (waitForEventualConsistency) {
+    await sleep(2500);
   }
 };
 


### PR DESCRIPTION
# Notes
Generate the lambda function name for each test so that it is unique and
not reused between tests.  I was seeing some resource conflict exceptions
and suspect that at least some of them were because we are re using the
lambda function name, and that is causing it to get updated more than
would be expected for a single test.  This should also make it a bit easier
to use, as a nice side effect.

Also wait for RC to be consistent when we need to for deleting the remote
configs which should make the clearing remote config test more reliable.  I think this passed before on the integration tests because I merged that test in at the same time as skipping lambda events for remote instrumenter events, so it would have caught it on that event that we now skip.