### PR TITLE
[SVLS-6405] Redact remote instrumenter logs

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -52,15 +52,19 @@ class Logger {
   }
 
   logObject(event) {
-    console.log(JSON.stringify(event));
+    console.log(this.redact(JSON.stringify(event)));
   }
 
   log(message) {
-    console.log("[Datadog Remote Instrumenter] " + message);
+    console.log(this.redact("[Datadog Remote Instrumenter] " + message));
   }
 
   error(message) {
-    console.error("[Datadog Remote Instrumenter] " + message);
+    console.error(this.redact("[Datadog Remote Instrumenter] " + message));
+  }
+
+  redact(log) {
+    return log.replace(/"DD_API_KEY":.*,/, `"DD_API_KEY":"****",`);
   }
 }
 exports.logger = new Logger();


### PR DESCRIPTION
Context
---
This PR prevents us from logging DD_API_KEY (sometimes set as an environment variable on instrumented lambdas). 

Testing
---
Built layer and added it to test instrumenter. [Example redacted log](https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdatadog-remote-instrumenter/log-events/2025$252F02$252F24$252F$255B$2524LATEST$255D0f6f76416f1d42bc9db013730cbd4abc/2025$252F02$252F24$252F$255B$2524LATEST$255D0f6f76416f1d42bc9db013730cbd4abc$3Fstart$3D1740412424385$26refEventId$3D38812494018796904483382056268589169656074937438553899069). 

Note: for some reason this messes up CloudWatch's pretty formatting, not sure if there's anything we can do about that.
