### PR TITLE
Update integration test api key secret

### DIFF
--- a/integration-tests/infrastructure/bin/infrastructure.ts
+++ b/integration-tests/infrastructure/bin/infrastructure.ts
@@ -53,7 +53,7 @@ class TestingStack extends Stack {
         InstrumenterFunctionName: functionName,
         TrailName: trailName,
         DdSite: "datad0g.com",
-        DdApiKey: SecretValue.secretsManager("Remote_Instrumenter_Test_API_Key"),
+        DdApiKey: SecretValue.secretsManager("Remote_Instrumenter_Test_API_Key_20250226"),
         BucketName: bucketName,
         DdRemoteInstrumentLayerAwsAccount: "425362996713",
         DdRemoteInstrumentLayerVersion: version,


### PR DESCRIPTION
# Notes
This will force the remote instrumenter to use the new secret over the one that is being removed.

# Testing
* See the key, [sso link](https://d-906757b57c.awsapps.com/start/#/console?account_id=425362996713&role_name=account-admin-8h&destination=https%3A%2F%2Fca-central-1.console.aws.amazon.com%2Fsecretsmanager%2Fsecret%3Fname%3DRemote_Instrumenter_Test_API_Key_20250226%26region%3Dca-central-1%26tab%3Dreplication
)

# Next steps
1. Deploy this change
2. Delete `Remote_Instrumenter_Test_API_Key ` secret
3. Revoke [API key](https://dd.datad0g.com/organization-settings/api-keys?filter=alex%20angelillo&id=b44e9828-760d-4b71-ac26-34956d15f3d9)