### PR TITLE
Consolidate runtime support config

### DIFF
--- a/integration-tests/scheduled-events.test.js
+++ b/integration-tests/scheduled-events.test.js
@@ -112,10 +112,28 @@ describe("Remote instrumenter scheduled event tests", () => {
     expect(isInstrumented).toStrictEqual(true);
   });
 
+  it.each([
+    ["nodejs20.x", Runtime.nodejs20x],
+    ["python3.10", Runtime.python310],
+  ])(
+    "function with runtime %s gets instrumented",
+    async (runtimeName, runtimeValue) => {
+      const { FunctionName: functionName } = await createFunction({
+        Tags: { foo: "bar" },
+        Runtime: runtimeValue,
+      });
+      await setRemoteConfig();
+      await invokeLambdaWithScheduledEvent();
+
+      const isInstrumented = await isFunctionInstrumented(functionName);
+      expect(isInstrumented).toStrictEqual(true);
+    },
+  );
+
   it("function with unsupported runtime does not get instrumented", async () => {
     const { FunctionName: functionName } = await createFunction({
       Tags: { foo: "bar" },
-      Runtime: Runtime.java21,
+      Runtime: Runtime.providedal2,
     });
     await setRemoteConfig();
 

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,7 @@ const {
   CONFIG_HASH_KEY,
   CONFIG_CACHE_TTL_MS,
   CONFIG_STATUS_EXPIRED,
+  SUPPORTED_RUNTIME_CONFIGURATIONS,
 } = require("./consts");
 const { getApplyState } = require("./apply-state");
 
@@ -31,14 +32,17 @@ class RcConfig {
     this.setRcConfigVersion(configMeta.custom?.v);
     this.setConfigVersion(configJSON.config_version);
     this.setEntityType(configJSON.entity_type);
+
+    Object.values(SUPPORTED_RUNTIME_CONFIGURATIONS).forEach((config) => {
+      this.setField(
+        config.configField,
+        config.getFromJsonConfig(configJSON),
+        "number",
+        true,
+      );
+    });
     this.setExtensionVersion(
       configJSON.instrumentation_settings?.extension_version,
-    );
-    this.setNodeLayerVersion(
-      configJSON.instrumentation_settings?.node_layer_version,
-    );
-    this.setPythonLayerVersion(
-      configJSON.instrumentation_settings?.python_layer_version,
     );
     this.setDDTraceEnabled(
       configJSON.instrumentation_settings?.dd_trace_enabled,
@@ -95,6 +99,16 @@ class RcConfig {
     }
   }
 
+  setField(field, value, type, allowUndefined = false) {
+    if ((allowUndefined && value === undefined) || typeof value === type) {
+      this[field] = value;
+    } else {
+      throw this.configurationError(
+        `${field} must be a ${type}, but received '${value}'`,
+      );
+    }
+  }
+
   setExtensionVersion(extensionVersion) {
     if (
       extensionVersion === undefined ||
@@ -104,32 +118,6 @@ class RcConfig {
     } else {
       throw this.configurationError(
         `extension version must be a number, but received '${extensionVersion}'`,
-      );
-    }
-  }
-
-  setNodeLayerVersion(nodeLayerVersion) {
-    if (
-      nodeLayerVersion === undefined ||
-      typeof nodeLayerVersion === "number"
-    ) {
-      this.nodeLayerVersion = nodeLayerVersion;
-    } else {
-      throw this.configurationError(
-        `node layer version must be a number, but received '${nodeLayerVersion}'`,
-      );
-    }
-  }
-
-  setPythonLayerVersion(pythonLayerVersion) {
-    if (
-      pythonLayerVersion === undefined ||
-      typeof pythonLayerVersion === "number"
-    ) {
-      this.pythonLayerVersion = pythonLayerVersion;
-    } else {
-      throw this.configurationError(
-        `python layer version must be a number, but received '${pythonLayerVersion}'`,
       );
     }
   }

--- a/src/consts.js
+++ b/src/consts.js
@@ -3,7 +3,28 @@ const NODE = "node";
 exports.NODE = NODE;
 const PYTHON = "python";
 exports.PYTHON = PYTHON;
-exports.SUPPORTED_RUNTIMES = [NODE, PYTHON];
+
+const SUPPORTED_RUNTIME_CONFIGURATIONS = {
+  [NODE]: {
+    layerName: "Datadog-Node",
+    configField: "nodeLayerVersion",
+    getFromJsonConfig: (configJSON) =>
+      configJSON.instrumentation_settings?.node_layer_version,
+    isSupportedRuntime: (runtime) => runtime.toLowerCase().includes(NODE),
+  },
+  [PYTHON]: {
+    layerName: "Datadog-Python",
+    configField: "pythonLayerVersion",
+    getFromJsonConfig: (configJSON) =>
+      configJSON.instrumentation_settings?.python_layer_version,
+    isSupportedRuntime: (runtime) => runtime.toLowerCase().includes(PYTHON),
+  },
+};
+exports.SUPPORTED_RUNTIME_CONFIGURATIONS = SUPPORTED_RUNTIME_CONFIGURATIONS;
+exports.getRuntimeConfig = (runtime) =>
+  Object.entries(SUPPORTED_RUNTIME_CONFIGURATIONS).find(([, config]) =>
+    config.isSupportedRuntime(runtime),
+  )?.[1];
 
 // Event Types
 exports.LAMBDA_EVENT = "LambdaEvent";

--- a/src/functions.js
+++ b/src/functions.js
@@ -18,9 +18,6 @@ const {
   DD_API_KEY_SECRET_ARN,
   DD_SITE,
   VERSION,
-  SUPPORTED_RUNTIMES,
-  NODE,
-  PYTHON,
   INSTRUMENT,
   TAG,
   FUNCTION_NAME,
@@ -29,6 +26,8 @@ const {
   REMOTE_INSTRUMENTER_FUNCTION,
   UNSUPPORTED_RUNTIME,
   ALREADY_CORRECT_EXTENSION_AND_LAYER,
+  SUPPORTED_RUNTIME_CONFIGURATIONS,
+  getRuntimeConfig,
 } = require("./consts");
 
 /**
@@ -267,9 +266,9 @@ function isInstrumented(lambdaFunc) {
   // Since the above environment variables can be configured
   // in a datadog.yaml file, check if a datadog layer is present
   const hasDatadogLayer =
-    hasLayerMatching(lambdaFunc, "Datadog-Python") ||
-    hasLayerMatching(lambdaFunc, "Datadog-Node") ||
-    hasLayerMatching(lambdaFunc, "Datadog-Extension");
+    Object.values(SUPPORTED_RUNTIME_CONFIGURATIONS).some((runtimeConfig) =>
+      hasLayerMatching(lambdaFunc, runtimeConfig.layerName),
+    ) || hasLayerMatching(lambdaFunc, "Datadog-Extension");
 
   if (hasDatadogLayer) {
     return true;
@@ -310,15 +309,9 @@ function isCorrectlyInstrumented({
   }
 
   // Check if the lambda layer version is correct
-  let expectedLayerName;
-  let expectedLayerVersion;
-  if (targetLambdaRuntime.toLowerCase().includes(PYTHON)) {
-    expectedLayerName = "Datadog-Python";
-    expectedLayerVersion = config.pythonLayerVersion;
-  } else if (targetLambdaRuntime.toLowerCase().includes(NODE)) {
-    expectedLayerName = "Datadog-Node";
-    expectedLayerVersion = config.nodeLayerVersion;
-  }
+  const runtimeConfig = getRuntimeConfig(targetLambdaRuntime);
+  const expectedLayerName = runtimeConfig?.layerName;
+  const expectedLayerVersion = config[runtimeConfig?.configField];
 
   let foundLayerVersion;
   for (const layer of layers) {
@@ -468,14 +461,7 @@ function needsInstrumentationUpdate(
   }
 
   // If it's an unsupported runtime, skip it
-  let isSupportedRuntime = false;
-  for (const supportedRuntime of SUPPORTED_RUNTIMES) {
-    if (runtime.includes(supportedRuntime)) {
-      isSupportedRuntime = true;
-      break;
-    }
-  }
-  if (!isSupportedRuntime) {
+  if (!getRuntimeConfig(runtime)) {
     if (emitProcessingLogs) {
       logger.emitFrontendProcessingEvent(
         functionName,

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -7,8 +7,6 @@ const {
 } = require("@datadog/datadog-ci/dist/commands/lambda/uninstrument.js");
 const {
   INSTRUMENT,
-  PYTHON,
-  NODE,
   UNINSTRUMENT,
   IN_PROGRESS,
   SUCCEEDED,
@@ -27,6 +25,7 @@ const { tagResourcesWithSlsTag, untagResourcesOfSlsTag } = require("./tag");
 const {
   REMOTE_INSTRUMENTATION_STARTED,
   REMOTE_INSTRUMENTATION_ENDED,
+  getRuntimeConfig,
 } = require("./consts");
 const {
   putApplyState,
@@ -48,10 +47,9 @@ function getExtensionAndRuntimeLayerVersion(runtime, config) {
     extensionVersion: config.extensionVersion,
   };
 
-  if (runtime.includes(NODE)) {
-    result.runtimeLayerVersion = config.nodeLayerVersion;
-  } else if (runtime.includes(PYTHON)) {
-    result.runtimeLayerVersion = config.pythonLayerVersion;
+  const runtimeConfig = getRuntimeConfig(runtime);
+  if (runtimeConfig) {
+    result.runtimeLayerVersion = config[runtimeConfig.configField];
   }
 
   return result;

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -139,7 +139,7 @@ describe("Config constructor", () => {
     expect(
       () => new RcConfig(sampleRcConfigID, testJSON, sampleRcMetadata),
     ).toThrow(
-      "Received invalid configuration: python layer version must be a number",
+      "Received invalid configuration: pythonLayerVersion must be a number",
     );
   });
 
@@ -158,7 +158,7 @@ describe("Config constructor", () => {
     expect(
       () => new RcConfig(sampleRcConfigID, testJSON, sampleRcMetadata),
     ).toThrow(
-      "Received invalid configuration: node layer version must be a number",
+      "Received invalid configuration: nodeLayerVersion must be a number",
     );
   });
 


### PR DESCRIPTION
### What does this PR do?

Consolidate the runtime support configuration so that everything about a specific runtime is in one place.  This allows us to make a change in 1 place to start supporting new runtimes.  In the future we plan to support the same set of runtimes that the Datadog CI supports, but this PR does not make any functional changes.

Some of the type checking is a bit unnatural since we're doing it explicitly, if we ever make the effort to use typescript it'll handle that for us.

### Motivation
This will make it easier to add more runtimes

### Testing Guidelines

* Unit tests cover same thing, added integration test explicitly for runtimes

### Additional Notes
* Datadog CI docs: https://docs.datadoghq.com/serverless/libraries_integrations/cli/
* JIRA: https://datadoghq.atlassian.net/browse/SVLS-7139

