### PR TITLE
[SVLS-7537] Add retries for config fetch on new 'no configs received'

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -455,9 +455,3 @@ function updateCache(configs) {
   CONFIG_CACHE.expirationTime = Date.now() + CONFIG_CACHE_TTL_MS;
 }
 exports.updateCache = updateCache;
-
-function invalidateCache() {
-  CONFIG_CACHE.configs = null;
-  CONFIG_CACHE.expirationTime = null;
-}
-exports.invalidateCache = invalidateCache;

--- a/src/config.js
+++ b/src/config.js
@@ -18,6 +18,7 @@ const {
   SUPPORTED_RUNTIME_CONFIGURATIONS,
 } = require("./consts");
 const { getApplyState } = require("./apply-state");
+const { sleep } = require("./sleep");
 
 // Initialize config cache
 const CONFIG_CACHE = {
@@ -222,6 +223,7 @@ async function getConfigsFromRC(s3Client, accountID, region) {
     },
     cached_target_files: [],
   };
+  logger.logObject(payload);
 
   let configs = [];
   await axios
@@ -381,6 +383,36 @@ async function configHasChanged(client, configs) {
 }
 exports.configHasChanged = configHasChanged;
 
+async function getConfigsWithRetry(s3Client, context) {
+  let configs = await getConfigs(s3Client, context);
+  let configChanged = await configHasChanged(s3Client, configs);
+
+  // If we detect a config change and newly receive no configs, retry fetching configs up to 2 more times
+  let retryCount = 0;
+  const maxRetries = 2;
+  while (configChanged && configs.length === 0 && retryCount < maxRetries) {
+    retryCount++;
+    logger.log(
+      `Config changed but no configs found. Retrying attempt ${retryCount}/${maxRetries}`,
+    );
+
+    // Wait for the cache TTL so that we don't exhaust our cache bypass limit
+    await sleep(CONFIG_CACHE_TTL_MS);
+    configs = await getConfigs(s3Client, context);
+    configChanged = await configHasChanged(s3Client, configs);
+
+    // Stop retrying if we now have configs
+    if (configs.length > 0) {
+      logger.log(
+        `Found ${configs.length} configs on retry attempt ${retryCount}`,
+      );
+      break;
+    }
+  }
+  return { configs, configChanged };
+}
+exports.getConfigsWithRetry = getConfigsWithRetry;
+
 async function updateConfigHash(client, configs) {
   const newConfigHash = crypto
     .createHash("sha256", "datadog-remote-instrumenter")
@@ -423,3 +455,9 @@ function updateCache(configs) {
   CONFIG_CACHE.expirationTime = Date.now() + CONFIG_CACHE_TTL_MS;
 }
 exports.updateCache = updateCache;
+
+function invalidateCache() {
+  CONFIG_CACHE.configs = null;
+  CONFIG_CACHE.expirationTime = null;
+}
+exports.invalidateCache = invalidateCache;

--- a/src/config.js
+++ b/src/config.js
@@ -223,7 +223,6 @@ async function getConfigsFromRC(s3Client, accountID, region) {
     },
     cached_target_files: [],
   };
-  logger.logObject(payload);
 
   let configs = [];
   await axios
@@ -235,6 +234,10 @@ async function getConfigsFromRC(s3Client, accountID, region) {
       logger.error(error);
       throw new Error("Failed to retrieve configs");
     });
+
+  if (configs.length === 0) {
+    logger.logObject(payload);
+  }
   return configs;
 }
 

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,5 +1,5 @@
 const cfnResponse = require("cfn-response"); // file will be auto-injected by CloudFormation
-const { getConfigs, configHasChanged, updateConfigHash } = require("./config");
+const { getConfigsWithRetry, updateConfigHash } = require("./config");
 const { logger } = require("./logger");
 const {
   isLambdaManagementEvent,
@@ -56,7 +56,7 @@ exports.handler = async (event, context) => {
   // If it's a stack event, send a response to CloudFormation for custom resource management
   if (isStackCreatedEvent(event)) {
     try {
-      const configs = await getConfigs(s3Client, context);
+      const configs = await getConfigsWithRetry(s3Client, context);
       const allFunctions = await getAllFunctions(lambdaClient);
       const functionsToCheck = await enrichFunctionsWithTags(
         lambdaClient,
@@ -126,7 +126,7 @@ exports.handler = async (event, context) => {
 
     let configs;
     try {
-      configs = await getConfigs(s3Client, context);
+      configs = await getConfigsWithRetry(s3Client, context);
     } catch (error) {
       // This pulls the reason from the error, just stringifying it does not return the message
       const errorDetails = JSON.parse(
@@ -150,8 +150,11 @@ exports.handler = async (event, context) => {
   else if (isScheduledInvocationEvent(event)) {
     logger.log("Received an invocation from the scheduler.");
     const errors = await listErrors(s3Client);
-    const configs = await getConfigs(s3Client, context);
-    const configChanged = await configHasChanged(s3Client, configs);
+    const { configs, configChanged } = await getConfigsWithRetry(
+      s3Client,
+      context,
+    );
+
     let functionsToCheck = [];
     if (configChanged) {
       // If the config has changed, check all functions for instrumentation

--- a/src/handler.js
+++ b/src/handler.js
@@ -56,7 +56,8 @@ exports.handler = async (event, context) => {
   // If it's a stack event, send a response to CloudFormation for custom resource management
   if (isStackCreatedEvent(event)) {
     try {
-      const configs = await getConfigsWithRetry(s3Client, context);
+      const configResult = await getConfigsWithRetry(s3Client, context);
+      const configs = configResult.configs;
       const allFunctions = await getAllFunctions(lambdaClient);
       const functionsToCheck = await enrichFunctionsWithTags(
         lambdaClient,
@@ -126,7 +127,8 @@ exports.handler = async (event, context) => {
 
     let configs;
     try {
-      configs = await getConfigsWithRetry(s3Client, context);
+      const configResult = await getConfigsWithRetry(s3Client, context);
+      configs = configResult.configs;
     } catch (error) {
       // This pulls the reason from the error, just stringifying it does not return the message
       const errorDetails = JSON.parse(

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -23,6 +23,9 @@ const {
 jest.mock("axios", () => ({
   post: jest.fn(),
 }));
+jest.mock("../src/sleep", () => ({
+  sleep: jest.fn().mockResolvedValue(),
+}));
 
 describe("Config constructor", () => {
   it("creates an RcConfig object out of well-formed JSON", () => {
@@ -865,6 +868,14 @@ describe("getConfigsWithRetry", () => {
     mockedAxios = require("axios");
     mockedAxios.post.mockReset();
     mockS3Client.send.mockReset();
+    const { sleep } = require("../src/sleep");
+    sleep.mockClear();
+    // Setup sleep mock to invalidate cache when called (simulates waiting for cache TTL)
+    sleep.mockImplementation(() => {
+      CONFIG_CACHE.configs = null;
+      CONFIG_CACHE.expirationTime = null;
+      return Promise.resolve();
+    });
     process.env.AWS_REGION = "us-east-1";
     process.env.DD_S3_BUCKET = "test-bucket";
     process.env.AWS_LAMBDA_FUNCTION_NAME = "test-function";
@@ -1105,7 +1116,7 @@ describe("getConfigsWithRetry", () => {
 
     // Check that there were two calls to RC
     expect(mockedAxios.post).toHaveBeenCalledTimes(2);
-  }, 10000);
+  });
 
   test("should stop retrying after max retries", async () => {
     const existingConfig = new RcConfig(
@@ -1156,5 +1167,5 @@ describe("getConfigsWithRetry", () => {
 
     // Check that there were three calls to RC
     expect(mockedAxios.post).toHaveBeenCalledTimes(3);
-  }, 20000);
+  });
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -5,6 +5,8 @@ const {
   getConfigsFromResponse,
   getConfigs,
   CONFIG_CACHE,
+  invalidateCache,
+  getConfigsWithRetry,
 } = require("../src/config");
 const {
   FILTER_TYPES,
@@ -641,6 +643,19 @@ describe("Config cache", () => {
       );
     });
   });
+
+  describe("invalidateCache", () => {
+    test("invalidates cache", () => {
+      const newConfigs = [sampleRcConfig, sampleRcConfig];
+      updateCache(newConfigs);
+      expect(isCacheValid()).toBe(true);
+
+      invalidateCache();
+      expect(CONFIG_CACHE.configs).toBeNull();
+      expect(CONFIG_CACHE.expirationTime).toBeNull();
+      expect(isCacheValid()).toBe(false);
+    });
+  });
 });
 
 describe("getConfigs", () => {
@@ -656,8 +671,7 @@ describe("getConfigs", () => {
       invokedFunctionArn:
         "arn:aws:lambda:us-east-1:123456789012:function:test-function",
     };
-    CONFIG_CACHE.configs = null;
-    CONFIG_CACHE.expirationTime = null;
+    invalidateCache();
     mockedAxios = require("axios");
     mockedAxios.post.mockReset();
     process.env.AWS_REGION = "us-east-1";
@@ -844,4 +858,315 @@ describe("getConfigs", () => {
     expect(CONFIG_CACHE.configs).toEqual(oldConfigs);
     expect(CONFIG_CACHE.expirationTime).toBe(expirationTime);
   });
+});
+
+describe("getConfigsWithRetry", () => {
+  let mockS3Client;
+  let mockContext;
+  let mockedAxios;
+
+  beforeEach(() => {
+    mockS3Client = {
+      send: jest.fn(),
+    };
+    mockContext = {
+      invokedFunctionArn:
+        "arn:aws:lambda:us-east-1:123456789012:function:test-function",
+    };
+    invalidateCache();
+    mockedAxios = require("axios");
+    mockedAxios.post.mockReset();
+    mockS3Client.send.mockReset();
+    process.env.AWS_REGION = "us-east-1";
+    process.env.DD_S3_BUCKET = "test-bucket";
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "test-function";
+  });
+
+  test("should only fetch configs once when config has not changed", async () => {
+    const existingConfig = new RcConfig(
+      "test-id",
+      sampleRcTestJSON,
+      sampleRcMetadata,
+    );
+    existingConfig.awsAccountId = "123456789012";
+    existingConfig.awsRegion = "us-east-1";
+    existingConfig.instrumenterFunctionName = "test-function";
+    const existingConfigs = [existingConfig];
+
+    const path = "datadog/2/SERVERLESS_REMOTE_INSTRUMENTATION/test-id";
+    const rcResponse = {
+      data: {
+        target_files: [
+          {
+            path: path,
+            raw: btoa(JSON.stringify(sampleRcTestJSON)),
+          },
+        ],
+        client_configs: [path],
+        targets: btoa(
+          JSON.stringify({
+            signed: {
+              targets: {
+                [path]: sampleRcMetadata,
+              },
+            },
+          }),
+        ),
+      },
+    };
+    mockedAxios.post.mockResolvedValueOnce(rcResponse);
+
+    const existingConfigHash = require("crypto")
+      .createHash("sha256", "datadog-remote-instrumenter")
+      .update(JSON.stringify(existingConfigs))
+      .digest("hex");
+
+    mockS3Client.send.mockImplementation(() => {
+      return Promise.resolve({
+        Body: {
+          transformToString: () => Promise.resolve(existingConfigHash),
+        },
+      });
+    });
+
+    const { configs, configChanged } = await getConfigsWithRetry(
+      mockS3Client,
+      mockContext,
+    );
+
+    // Check that the same configs are returned
+    expect(configChanged).toBe(false);
+    expect(JSON.stringify(configs)).toEqual(JSON.stringify(existingConfigs));
+    expect(CONFIG_CACHE.configs).toEqual(existingConfigs);
+
+    // Check that there was only one call to RC
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+  });
+
+  test("should only fetch configs once when different configs are returned", async () => {
+    const newConfig = new RcConfig(
+      "test-id",
+      sampleRcTestJSON,
+      sampleRcMetadata,
+    );
+    newConfig.awsAccountId = "123456789012";
+    newConfig.awsRegion = "us-east-1";
+    newConfig.instrumenterFunctionName = "test-function";
+    const newConfigs = [newConfig];
+
+    const path = "datadog/2/SERVERLESS_REMOTE_INSTRUMENTATION/test-id";
+    const rcResponse = {
+      data: {
+        target_files: [
+          {
+            path: path,
+            raw: btoa(JSON.stringify(sampleRcTestJSON)),
+          },
+        ],
+        client_configs: [path],
+        targets: btoa(
+          JSON.stringify({
+            signed: {
+              targets: {
+                [path]: sampleRcMetadata,
+              },
+            },
+          }),
+        ),
+      },
+    };
+    mockedAxios.post.mockResolvedValueOnce(rcResponse);
+
+    const existingConfigHash = require("crypto")
+      .createHash("sha256", "datadog-remote-instrumenter")
+      .update(JSON.stringify([{}]))
+      .digest("hex");
+
+    mockS3Client.send.mockImplementation(() => {
+      return Promise.resolve({
+        Body: {
+          transformToString: () => Promise.resolve(existingConfigHash),
+        },
+      });
+    });
+
+    const { configs, configChanged } = await getConfigsWithRetry(
+      mockS3Client,
+      mockContext,
+    );
+
+    // Check that configs are returned
+    expect(configChanged).toBe(true);
+    expect(JSON.stringify(configs)).toEqual(JSON.stringify(newConfigs));
+    expect(CONFIG_CACHE.configs).toEqual(newConfigs);
+
+    // Check that there was only one call to RC
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+  });
+
+  test("should only fetch configs once when there are still no configs", async () => {
+    const rcResponse = {
+      data: {
+        targets: btoa(
+          JSON.stringify({
+            signed: {
+              targets: {},
+            },
+          }),
+        ),
+      },
+    };
+    mockedAxios.post.mockResolvedValueOnce(rcResponse);
+
+    const existingConfigHash = require("crypto")
+      .createHash("sha256", "datadog-remote-instrumenter")
+      .update(JSON.stringify([]))
+      .digest("hex");
+
+    mockS3Client.send.mockImplementation(() => {
+      return Promise.resolve({
+        Body: {
+          transformToString: () => Promise.resolve(existingConfigHash),
+        },
+      });
+    });
+
+    const { configs, configChanged } = await getConfigsWithRetry(
+      mockS3Client,
+      mockContext,
+    );
+
+    // Check that no configs are returned
+    expect(configChanged).toBe(false);
+    expect(configs.length).toBe(0);
+    expect(CONFIG_CACHE.configs).toEqual([]);
+
+    // Check that there was only one call to RC
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+  });
+
+  test("should retry fetching configs when no configs are incorrectly returned on first attempt", async () => {
+    const existingConfig = new RcConfig(
+      "test-id",
+      sampleRcTestJSON,
+      sampleRcMetadata,
+    );
+    existingConfig.awsAccountId = "123456789012";
+    existingConfig.awsRegion = "us-east-1";
+    existingConfig.instrumenterFunctionName = "test-function";
+    const existingConfigs = [existingConfig];
+
+    const path = "datadog/2/SERVERLESS_REMOTE_INSTRUMENTATION/test-id";
+    const rcResponse = {
+      data: {
+        target_files: [
+          {
+            path: path,
+            raw: btoa(JSON.stringify(sampleRcTestJSON)),
+          },
+        ],
+        client_configs: [path],
+        targets: btoa(
+          JSON.stringify({
+            signed: {
+              targets: {
+                [path]: sampleRcMetadata,
+              },
+            },
+          }),
+        ),
+      },
+    };
+
+    const noConfigsResponse = {
+      data: {
+        targets: btoa(
+          JSON.stringify({
+            signed: {
+              targets: {},
+            },
+          }),
+        ),
+      },
+    };
+    mockedAxios.post.mockResolvedValueOnce(noConfigsResponse);
+    mockedAxios.post.mockResolvedValueOnce(rcResponse);
+
+    const existingConfigHash = require("crypto")
+      .createHash("sha256", "datadog-remote-instrumenter")
+      .update(JSON.stringify(existingConfigs))
+      .digest("hex");
+
+    mockS3Client.send.mockImplementation(() => {
+      return Promise.resolve({
+        Body: {
+          transformToString: () => Promise.resolve(existingConfigHash),
+        },
+      });
+    });
+
+    const { configs, configChanged } = await getConfigsWithRetry(
+      mockS3Client,
+      mockContext,
+    );
+
+    // Check that configs are returned
+    expect(configChanged).toBe(false);
+    expect(JSON.stringify(configs)).toEqual(JSON.stringify(existingConfigs));
+    expect(CONFIG_CACHE.configs).toEqual(existingConfigs);
+
+    // Check that there were two calls to RC
+    expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+  }, 10000);
+
+  test("should stop retrying after max retries", async () => {
+    const existingConfig = new RcConfig(
+      "test-id",
+      sampleRcTestJSON,
+      sampleRcMetadata,
+    );
+    existingConfig.awsAccountId = "123456789012";
+    existingConfig.awsRegion = "us-east-1";
+    existingConfig.instrumenterFunctionName = "test-function";
+    const existingConfigs = [existingConfig];
+
+    const noConfigsResponse = {
+      data: {
+        targets: btoa(
+          JSON.stringify({
+            signed: {
+              targets: {},
+            },
+          }),
+        ),
+      },
+    };
+    mockedAxios.post.mockResolvedValue(noConfigsResponse);
+
+    const existingConfigHash = require("crypto")
+      .createHash("sha256", "datadog-remote-instrumenter")
+      .update(JSON.stringify(existingConfigs))
+      .digest("hex");
+
+    mockS3Client.send.mockImplementation(() => {
+      return Promise.resolve({
+        Body: {
+          transformToString: () => Promise.resolve(existingConfigHash),
+        },
+      });
+    });
+
+    const { configs, configChanged } = await getConfigsWithRetry(
+      mockS3Client,
+      mockContext,
+    );
+
+    // Check that configs are returned
+    expect(configChanged).toBe(true);
+    expect(JSON.stringify(configs)).toEqual(JSON.stringify([]));
+    expect(CONFIG_CACHE.configs).toEqual([]);
+
+    // Check that there were three calls to RC
+    expect(mockedAxios.post).toHaveBeenCalledTimes(3);
+  }, 20000);
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -5,7 +5,6 @@ const {
   getConfigsFromResponse,
   getConfigs,
   CONFIG_CACHE,
-  invalidateCache,
   getConfigsWithRetry,
 } = require("../src/config");
 const {
@@ -643,19 +642,6 @@ describe("Config cache", () => {
       );
     });
   });
-
-  describe("invalidateCache", () => {
-    test("invalidates cache", () => {
-      const newConfigs = [sampleRcConfig, sampleRcConfig];
-      updateCache(newConfigs);
-      expect(isCacheValid()).toBe(true);
-
-      invalidateCache();
-      expect(CONFIG_CACHE.configs).toBeNull();
-      expect(CONFIG_CACHE.expirationTime).toBeNull();
-      expect(isCacheValid()).toBe(false);
-    });
-  });
 });
 
 describe("getConfigs", () => {
@@ -671,7 +657,8 @@ describe("getConfigs", () => {
       invokedFunctionArn:
         "arn:aws:lambda:us-east-1:123456789012:function:test-function",
     };
-    invalidateCache();
+    CONFIG_CACHE.configs = null;
+    CONFIG_CACHE.expirationTime = null;
     mockedAxios = require("axios");
     mockedAxios.post.mockReset();
     process.env.AWS_REGION = "us-east-1";
@@ -873,7 +860,8 @@ describe("getConfigsWithRetry", () => {
       invokedFunctionArn:
         "arn:aws:lambda:us-east-1:123456789012:function:test-function",
     };
-    invalidateCache();
+    CONFIG_CACHE.configs = null;
+    CONFIG_CACHE.expirationTime = null;
     mockedAxios = require("axios");
     mockedAxios.post.mockReset();
     mockS3Client.send.mockReset();

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -34,7 +34,10 @@ describe("handler lambda management events", () => {
     functions.enrichFunctionsWithTags.mockReturnValue(enrichedFunction);
 
     const configsResult = ["a"];
-    config.getConfigs.mockReturnValue(configsResult);
+    config.getConfigsWithRetry.mockReturnValue({
+      configs: configsResult,
+      configChanged: true,
+    });
     instrument.instrumentFunctions.mockReturnValue(true);
 
     await handler.handler(event, context);
@@ -47,7 +50,10 @@ describe("handler lambda management events", () => {
       expect.anything(),
       [lambdaFunction],
     );
-    expect(config.getConfigs).toHaveBeenCalledWith(expect.anything(), context);
+    expect(config.getConfigsWithRetry).toHaveBeenCalledWith(
+      expect.anything(),
+      context,
+    );
     expect(instrument.instrumentFunctions).toHaveBeenCalledWith(
       expect.anything(),
       configsResult,
@@ -76,7 +82,7 @@ describe("handler lambda management events", () => {
     const error = () => {
       throw new Error("ERROR!");
     };
-    config.getConfigs.mockImplementation(error);
+    config.getConfigsWithRetry.mockImplementation(error);
     instrument.instrumentFunctions.mockReturnValue(true);
 
     await expect(handler.handler(event, context)).rejects.toThrow("ERROR!");
@@ -89,7 +95,10 @@ describe("handler lambda management events", () => {
       expect.anything(),
       [lambdaFunction],
     );
-    expect(config.getConfigs).toHaveBeenCalledWith(expect.anything(), context);
+    expect(config.getConfigsWithRetry).toHaveBeenCalledWith(
+      expect.anything(),
+      context,
+    );
     expect(instrument.instrumentFunctions).not.toHaveBeenCalled();
     expect(errorStorage.putError).toHaveBeenCalledWith(
       expect.anything(),
@@ -112,7 +121,10 @@ describe("scheduled invocation events", () => {
     const configsResult = ["a"];
 
     lambdaEvent.isScheduledInvocationEvent.mockReturnValue(true);
-    config.getConfigs.mockReturnValue(configsResult);
+    config.getConfigsWithRetry.mockReturnValue({
+      configs: configsResult,
+      configChanged: false,
+    });
     config.configHasChanged.mockReturnValue(false);
     errorStorage.listErrors.mockReturnValue(["function1", "function2"]);
     errorStorage.putError.mockReturnValue(true);
@@ -276,7 +288,10 @@ describe("stack create events", () => {
 
     lambdaEvent.isStackCreatedEvent.mockReturnValue(true);
     const configsResult = ["configs"];
-    config.getConfigs.mockReturnValue(configsResult);
+    config.getConfigsWithRetry.mockReturnValue({
+      configs: configsResult,
+      configChanged: true,
+    });
     functions.getAllFunctions.mockReturnValue("getAllFunctionsRV");
     functions.enrichFunctionsWithTags.mockReturnValue(
       "enrichFunctionsWithTagsRV",
@@ -320,7 +335,7 @@ describe("stack create events", () => {
     const context = "context";
 
     lambdaEvent.isStackCreatedEvent.mockReturnValue(true);
-    config.getConfigs.mockImplementation(() => {
+    config.getConfigsWithRetry.mockImplementation(() => {
       throw new Error();
     });
 


### PR DESCRIPTION
### What does this PR do?

This PR adds retries for fetching config from RC when:
- The previous scheduled invocation got > 0 configs from remote config (as determined by the config hash); and 
- The current invocation received no (0) configs from RC.

The retry logic is set up to:
- Retry up to 2 additional times, returning immediately if we get > 0 configs on a retry.
- Wait 6 seconds in between retries (enough time to invalidate the cache / ensure we don't exceed our RC cache bypass limit). The wait could add up to 12 seconds to the invocation duration; the cost for this should be small (tenth of a cent or less) and will only be incurred on mass-uninstrumentation events, which should be infrequent.


### Motivation

When we receive no configs, we mass-uninstrument all lambdas that are managed by remote instrumentation. We've observed an infrequent flake where we incorrectly receive no configs from RC, and we want to protect against this flake. 

### Testing Guidelines

- Unit tests for the retry behavior
- We already have integration tests for uninstrumenting on no configs
