### PR TITLE
Delete config hash when starting to instrument

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 const axios = require("axios");
 const { logger } = require("./logger");
 const {
+  DeleteObjectCommand,
   GetObjectCommand,
   PutObjectCommand,
   NoSuchKey,
@@ -443,6 +444,15 @@ async function updateConfigHash(client, configs) {
   }
 }
 exports.updateConfigHash = updateConfigHash;
+
+async function deleteConfigHash(client) {
+  const command = new DeleteObjectCommand({
+    Bucket: process.env.DD_S3_BUCKET,
+    Key: CONFIG_HASH_KEY,
+  });
+  await client.send(command);
+}
+exports.deleteConfigHash = deleteConfigHash;
 
 function isCacheValid() {
   return (

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,5 +1,9 @@
 const cfnResponse = require("cfn-response"); // file will be auto-injected by CloudFormation
-const { getConfigsWithRetry, updateConfigHash } = require("./config");
+const {
+  deleteConfigHash,
+  getConfigsWithRetry,
+  updateConfigHash,
+} = require("./config");
 const { logger } = require("./logger");
 const {
   isLambdaManagementEvent,
@@ -159,6 +163,7 @@ exports.handler = async (event, context) => {
 
     let functionsToCheck = [];
     if (configChanged) {
+      await deleteConfigHash(s3Client);
       // If the config has changed, check all functions for instrumentation
       // Get all functions in the customer's account
       const allFunctions = await getAllFunctions(lambdaClient);

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -109,15 +109,16 @@ describe("handler lambda management events", () => {
 });
 
 describe("scheduled invocation events", () => {
+  const event = {
+    "event-type": "Scheduled Instrumenter Invocation",
+  };
+  const context = "context";
+
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   test("Loads errors from s3", async () => {
-    const event = {
-      "event-type": "Scheduled Instrumenter Invocation",
-    };
-    const context = "context";
     const configsResult = ["a"];
 
     lambdaEvent.isScheduledInvocationEvent.mockReturnValue(true);
@@ -172,6 +173,36 @@ describe("scheduled invocation events", () => {
       expect.anything(),
       "error!",
     );
+  });
+
+  test("happy path", async () => {
+    const allFunctions = [{ FunctionName: "function1" }];
+
+    lambdaEvent.isScheduledInvocationEvent.mockReturnValue(true);
+    config.getConfigsWithRetry.mockReturnValue({
+      configs: ["a"],
+      configChanged: true,
+    });
+    config.deleteConfigHash.mockReturnValue(true);
+    errorStorage.listErrors.mockReturnValue([]);
+    functions.getAllFunctions.mockReturnValue(allFunctions);
+    functions.enrichFunctionsWithTags.mockReturnValue("enrichedFunctions");
+    instrument.instrumentFunctions.mockReturnValue(true);
+    config.updateConfigHash.mockReturnValue(true);
+    errorStorage.identifyNewErrorsAndResolvedErrors.mockReturnValue({
+      newErrors: [],
+      resolvedErrors: [],
+    });
+
+    await handler.handler(event, context);
+
+    expect(config.getConfigsWithRetry).toHaveBeenCalledTimes(1);
+    expect(config.deleteConfigHash).toHaveBeenCalledTimes(1);
+    expect(errorStorage.listErrors).toHaveBeenCalledTimes(1);
+    expect(functions.getAllFunctions).toHaveBeenCalledTimes(1);
+    expect(functions.enrichFunctionsWithTags).toHaveBeenCalledTimes(1);
+    expect(instrument.instrumentFunctions).toHaveBeenCalledTimes(1);
+    expect(config.updateConfigHash).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
### What does this PR do?
Delete the config hash when starting to instrument functions.  This is so that if the config hash changes back and forth between scheduled invocations where the instrumenter has had an error it will still attempt to fix the problem on the next scheduled invocation.

So long as the instrumenter continues to make progress on instrumenting functions it will always at least get closer to the correct end state, it doesn't leave functions in a state where it won't pick them back up.

### Motivation

JIRA: https://datadoghq.atlassian.net/browse/SVLS-7538

### Testing Guidelines

* Added unit test, integration tests go over this code path
