### PR TITLE
Add test confirming negative rules

### DIFF
--- a/integration-tests/jest.config.js
+++ b/integration-tests/jest.config.js
@@ -1,7 +1,8 @@
 const config = {
   globalTeardown: "./post-test-validation.js",
   setupFilesAfterEnv: ["./jest-setup-after-env.js"],
-  testMatch: ["**/integration-tests/**+(test|spec).[jt]s?(x)"],
+  // testMatch: ["**/integration-tests/**+(test|spec).[jt]s?(x)"],
+  testMatch: ["**/lambda-management-events.test.js"],
   testTimeout: 90000, // ms
 };
 

--- a/integration-tests/jest.config.js
+++ b/integration-tests/jest.config.js
@@ -1,8 +1,7 @@
 const config = {
   globalTeardown: "./post-test-validation.js",
   setupFilesAfterEnv: ["./jest-setup-after-env.js"],
-  // testMatch: ["**/integration-tests/**+(test|spec).[jt]s?(x)"],
-  testMatch: ["**/lambda-management-events.test.js"],
+  testMatch: ["**/integration-tests/**+(test|spec).[jt]s?(x)"],
   testTimeout: 90000, // ms
 };
 

--- a/integration-tests/lambda-management-events.test.js
+++ b/integration-tests/lambda-management-events.test.js
@@ -73,7 +73,31 @@ describe("Remote instrumenter lambda management event tests", () => {
   });
 
   it("can instrument a lambda function with deny rule", async () => {
-    // When there is a remote config
+    // Config will cause the function to be instrumented
+    await setRemoteConfig({
+      ruleFilters: [
+        {
+          key: "apple",
+          values: ["honeycrisp"],
+          filter_type: "tag",
+          allow: true,
+        },
+      ],
+    });
+
+    const { FunctionName: functionName } = await createFunction({
+      Tags: {
+        apple: "honeycrisp",
+        potato: "idaho",
+      },
+    });
+
+    const isInstrumented = await pollUntilTrue(60000, 5000, () =>
+      isFunctionInstrumented(functionName),
+    );
+    expect(isInstrumented).toStrictEqual(true);
+
+    // Exclude functions by tag
     await setRemoteConfig({
       ruleFilters: [
         {
@@ -91,29 +115,9 @@ describe("Remote instrumenter lambda management event tests", () => {
       ],
     });
 
-    // Create the uninstrumented function first so it will have been processed by the instrumenter
-    const { FunctionName: notInstrumentedFunctionName } = await createFunction({
-      Tags: {
-        apple: "honeycrisp",
-        potato: "idaho",
-      },
-    });
-    const { FunctionName: instrumentedFunctionName } = await createFunction({
-      Tags: {
-        apple: "honeycrisp",
-        potato: "yukonGold",
-      },
-    });
+    await invokeLambdaWithScheduledEvent();
 
-    // After some time
-    const isInstrumented = await pollUntilTrue(60000, 5000, () =>
-      isFunctionInstrumented(instrumentedFunctionName),
-    );
-    expect(isInstrumented).toStrictEqual(true);
-
-    const isUninstrumented = await isFunctionUninstrumented(
-      notInstrumentedFunctionName,
-    );
+    const isUninstrumented = await isFunctionUninstrumented(functionName);
     expect(isUninstrumented).toStrictEqual(true);
   });
 

--- a/integration-tests/lambda-management-events.test.js
+++ b/integration-tests/lambda-management-events.test.js
@@ -72,6 +72,51 @@ describe("Remote instrumenter lambda management event tests", () => {
     expect(isInstrumented).toStrictEqual(true);
   });
 
+  it("can instrument a lambda function with deny rule", async () => {
+    // When there is a remote config
+    await setRemoteConfig({
+      ruleFilters: [
+        {
+          key: "apple",
+          values: ["honeycrisp"],
+          filter_type: "tag",
+          allow: true,
+        },
+        {
+          key: "potato",
+          values: ["idaho"],
+          filter_type: "tag",
+          allow: false,
+        },
+      ],
+    });
+
+    // Create the uninstrumented function first so it will have been processed by the instrumenter
+    const { FunctionName: notInstrumentedFunctionName } = await createFunction({
+      Tags: {
+        apple: "honeycrisp",
+        potato: "idaho",
+      },
+    });
+    const { FunctionName: instrumentedFunctionName } = await createFunction({
+      Tags: {
+        apple: "honeycrisp",
+        potato: "yukonGold",
+      },
+    });
+
+    // After some time
+    const isInstrumented = await pollUntilTrue(60000, 5000, () =>
+      isFunctionInstrumented(instrumentedFunctionName),
+    );
+    expect(isInstrumented).toStrictEqual(true);
+
+    const isUninstrumented = await isFunctionUninstrumented(
+      notInstrumentedFunctionName,
+    );
+    expect(isUninstrumented).toStrictEqual(true);
+  });
+
   it("can instrument multiple new lambda functions", async () => {
     // When there is a remote config
     await setRemoteConfig();

--- a/integration-tests/scheduled-events.test.js
+++ b/integration-tests/scheduled-events.test.js
@@ -150,6 +150,47 @@ describe("Remote instrumenter scheduled event tests", () => {
     expect(isUninstrumented).toStrictEqual(true);
   });
 
+  it("handles function name deny rules", async () => {
+    const { FunctionName: excludedFunctionName } = await createFunction({
+      Tags: {
+        foo: "bar",
+      },
+    });
+    const { FunctionName: instrumentedFunctionName } = await createFunction({
+      Tags: {
+        foo: "bar",
+      },
+    });
+
+    await setRemoteConfig({
+      ruleFilters: [
+        {
+          key: "foo",
+          values: ["bar"],
+          filter_type: "tag",
+          allow: true,
+        },
+        {
+          key: "functionName",
+          values: [excludedFunctionName],
+          filter_type: "function_name",
+          allow: false,
+        },
+      ],
+    });
+
+    await invokeLambdaWithScheduledEvent();
+
+    const isInstrumented = await pollUntilTrue(60000, 5000, () =>
+      isFunctionInstrumented(instrumentedFunctionName),
+    );
+    expect(isInstrumented).toStrictEqual(true);
+
+    const isUninstrumented =
+      await isFunctionUninstrumented(excludedFunctionName);
+    expect(isUninstrumented).toStrictEqual(true);
+  });
+
   it("can upgrade layer versions when the config changes", async () => {
     const rc = await setRemoteConfig({
       extensionVersion: 66,

--- a/integration-tests/utilities/lambda-functions.js
+++ b/integration-tests/utilities/lambda-functions.js
@@ -18,12 +18,13 @@ const { getLambdaClient } = require("./aws-resources");
 const { sleep } = require("./sleep");
 
 const functionNamesToCleanUp = [];
+const functionNameCount = {};
 
 const createFunctions = async (lambdaProps, numFunctions = 1) => {
   const lambdaClient = await getLambdaClient();
   const createdFunctions = new Set();
   for (let i = 0; i < numFunctions; i++) {
-    const functionName = generateTestFunctionName(i);
+    const functionName = generateTestFunctionName();
 
     const zip = new JSZip();
     zip.file(
@@ -82,7 +83,7 @@ const createFunction = async (lambdaProps) => {
 };
 exports.createFunction = createFunction;
 
-function generateTestFunctionName(suffixNumber) {
+function generateTestFunctionName() {
   // Name the function after the test, picking the last 64 characters since
   // lambda limits function name length and that is probably the most descriptive
   let functionName =
@@ -91,8 +92,13 @@ function generateTestFunctionName(suffixNumber) {
       "",
     );
 
+  if (functionNameCount[functionName] === undefined) {
+    functionNameCount[functionName] = 0;
+  }
+  functionNameCount[functionName]++;
+
   const prefix = "ri-test-";
-  const suffix = `-${suffixNumber}`;
+  const suffix = `-${functionNameCount[functionName]}`;
   const maxLengthWithoutPrefixAndSuffix = 64 - prefix.length - suffix.length;
   if (functionName.length > maxLengthWithoutPrefixAndSuffix) {
     functionName = functionName.slice(


### PR DESCRIPTION
### What does this PR do?
Add a test to confirm that deny rules are working as intended.  Also a small change to how the function names are determined to make it so that createFunctions can be called multiple times within a single test.

### Motivation
Confirming functionality around allow:false rules.

### Testing Guidelines
* Test only change
