### PR TITLE
Add adaptive retries

### DIFF
--- a/src/aws-resources.js
+++ b/src/aws-resources.js
@@ -1,13 +1,47 @@
 const { LambdaClient } = require("@aws-sdk/client-lambda");
+const {
+  ResourceGroupsTaggingAPIClient,
+} = require("@aws-sdk/client-resource-groups-tagging-api");
+const { S3Client } = require("@aws-sdk/client-s3");
 
 let lambdaClient;
 const getLambdaClient = () => {
   if (!lambdaClient) {
     lambdaClient = new LambdaClient({
       region: process.env.AWS_REGION,
+      retryMode: "adaptive",
+      maxAttempts: 5,
     });
   }
   return lambdaClient;
 };
 
 exports.getLambdaClient = getLambdaClient;
+
+let taggingClient;
+const getTaggingClient = () => {
+  if (!taggingClient) {
+    taggingClient = new ResourceGroupsTaggingAPIClient({
+      region: process.env.AWS_REGION,
+      retryMode: "adaptive",
+      maxAttempts: 5,
+    });
+  }
+  return taggingClient;
+};
+
+exports.getTaggingClient = getTaggingClient;
+
+let s3Client;
+const getS3Client = () => {
+  if (!s3Client) {
+    s3Client = new S3Client({
+      region: process.env.AWS_REGION,
+      retryMode: "adaptive",
+      maxAttempts: 5,
+    });
+  }
+  return s3Client;
+};
+
+exports.getS3Client = getS3Client;

--- a/src/handler.js
+++ b/src/handler.js
@@ -22,16 +22,16 @@ const {
 } = require("./error-storage");
 const { ResourceNotFoundException } = require("@aws-sdk/client-lambda");
 const {
-  ResourceGroupsTaggingAPIClient,
-} = require("@aws-sdk/client-resource-groups-tagging-api");
-const { S3Client } = require("@aws-sdk/client-s3");
-const {
   getLambdaFunction,
   getAllFunctions,
   enrichFunctionsWithTags,
   getFunctionCount,
 } = require("./functions");
-const { getLambdaClient } = require("./aws-resources");
+const {
+  getLambdaClient,
+  getS3Client,
+  getTaggingClient,
+} = require("./aws-resources");
 const { instrumentFunctions } = require("./instrument");
 const {
   LAMBDA_EVENT,
@@ -43,12 +43,9 @@ const {
   SKIPPED,
 } = require("./consts");
 
-const awsRegion = process.env.AWS_REGION;
 const lambdaClient = getLambdaClient();
-const taggingClient = new ResourceGroupsTaggingAPIClient({
-  region: awsRegion,
-});
-const s3Client = new S3Client({ region: awsRegion });
+const taggingClient = getTaggingClient();
+const s3Client = getS3Client();
 
 exports.handler = async (event, context) => {
   logger.logObject(selectEventFieldsForLogging(event));


### PR DESCRIPTION
### What does this PR do?
Change the retry mode to adaptive for all of our AWS clients.  This will make it less likely they fail, at the potential cost of taking longer to succeed.  This should help larger batches of lambdas be instrumented without throttle errors.  Also set the retries to 5, and moved the other AWS clients into the aws-resources file and gave them getter functions so we don't need to pass them around as much, though this PR won't include any refactoring.  I kept the configurations for these separate for now since I'm not sure if we'll want to change them individually.

### Motivation
This should help with throttle errors for customers with many lambdas

### Testing Guidelines
Functionally this should be the same

### Additional Notes
* Adaptive retry strategy docs: https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html
