### PR TITLE
[SVLS-7729] Alternate tagging/instrumenting or uninstrumenting/tagging in batches

### DIFF
--- a/integration-tests/scheduled-events.test.js
+++ b/integration-tests/scheduled-events.test.js
@@ -373,7 +373,7 @@ describe("Remote instrumenter scheduled event tests", () => {
   });
 
   it("correctly tags instrumented functions", async () => {
-    const functions = await createFunctions({}, 21);
+    const functions = await createFunctions({}, 51);
     const functionNames = functions.map((lambda) => lambda.FunctionName);
     const functionArns = functions.map((lambda) => lambda.FunctionArn);
 
@@ -390,14 +390,14 @@ describe("Remote instrumenter scheduled event tests", () => {
 
     await invokeLambdaWithScheduledEvent();
 
-    // For each of the 21 functions
+    // For each of the 51 functions
     await expectFunctionsToBeInstrumented(functionNames);
 
-    // For each of the 21 functions
+    // For each of the 51 functions
     for (const functionArn of functionArns) {
       // Check that the function has the remote instrumenter tag
       const hasTag = await hasRemoteInstrumenterTag(functionArn);
       expect(hasTag).toStrictEqual(true);
     }
-  });
+  }, 120000);
 });

--- a/src/functions.js
+++ b/src/functions.js
@@ -205,10 +205,8 @@ function filterFunctionsToChangeInstrumentation(
   config,
   instrumentOutcome,
 ) {
-  const functionsToInstrument = [];
-  const functionsToUninstrument = [];
-  const functionsToTag = [];
-  const functionsToUntag = [];
+  const functionsToInstrumentOrTag = [];
+  const functionsToUninstrumentOrUntag = [];
   const emitProcessingLogs = functions.length === 1;
   for (const lambdaFunc of functions) {
     const { instrument, uninstrument, tag, untag } = needsInstrumentationUpdate(
@@ -217,23 +215,19 @@ function filterFunctionsToChangeInstrumentation(
       instrumentOutcome,
       emitProcessingLogs,
     );
-    if (instrument) {
-      functionsToInstrument.push(lambdaFunc);
-    } else if (uninstrument) {
-      functionsToUninstrument.push(lambdaFunc);
-    }
-
-    if (tag) {
-      functionsToTag.push(lambdaFunc);
-    } else if (untag) {
-      functionsToUntag.push(lambdaFunc);
+    if (instrument || tag) {
+      lambdaFunc.needsInstrumentation = instrument;
+      lambdaFunc.needsTagging = tag;
+      functionsToInstrumentOrTag.push(lambdaFunc);
+    } else if (uninstrument || untag) {
+      lambdaFunc.needsUninstrumentation = uninstrument;
+      lambdaFunc.needsUntagging = untag;
+      functionsToUninstrumentOrUntag.push(lambdaFunc);
     }
   }
   return {
-    functionsToInstrument: functionsToInstrument,
-    functionsToUninstrument: functionsToUninstrument,
-    functionsToTag: functionsToTag,
-    functionsToUntag: functionsToUntag,
+    functionsToInstrumentOrTag,
+    functionsToUninstrumentOrUntag,
   };
 }
 exports.filterFunctionsToChangeInstrumentation =

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -56,6 +56,15 @@ function getExtensionAndRuntimeLayerVersion(runtime, config) {
 }
 exports.getExtensionAndRuntimeLayerVersion = getExtensionAndRuntimeLayerVersion;
 
+function createFunctionBatches(functions, batchSize = 50) {
+  const batches = [];
+  for (let i = 0; i < functions.length; i += batchSize) {
+    batches.push(functions.slice(i, i + batchSize));
+  }
+  return batches;
+}
+exports.createFunctionBatches = createFunctionBatches;
+
 async function instrumentWithDatadogCi(
   functionToInstrument,
   instrument,
@@ -170,61 +179,93 @@ async function instrumentFunctions(
   }
 
   for (const config of configs) {
-    let {
-      functionsToInstrument,
-      functionsToUninstrument,
-      functionsToTag,
-      functionsToUntag,
-    } = filterFunctionsToChangeInstrumentation(
-      functionsToCheck,
-      config,
-      instrumentOutcome,
-    );
-    logger.log(
-      `Functions to instrument: ${functionsToInstrument.map((f) => f.FunctionName)}`,
-    );
-    logger.log(
-      `Functions to uninstrument: ${functionsToUninstrument.map((f) => f.FunctionName)}`,
-    );
-    logger.log(
-      `Functions to tag: ${functionsToTag.map((f) => f.FunctionName)}`,
-    );
-    logger.log(
-      `Functions to untag: ${functionsToUntag.map((f) => f.FunctionName)}`,
-    );
-
-    await tagResourcesWithSlsTag(
-      taggingClient,
-      functionsToTag.map((f) => f.FunctionArn),
-    );
-
-    // Instrument and tag the functions that need to be instrumented
-    for (const functionToInstrument of functionsToInstrument) {
-      await instrumentWithDatadogCi(
-        functionToInstrument,
-        true,
+    const { functionsToInstrumentOrTag, functionsToUninstrumentOrUntag } =
+      filterFunctionsToChangeInstrumentation(
+        functionsToCheck,
         config,
         instrumentOutcome,
       );
+    logger.log(
+      `Functions to instrument: ${functionsToInstrumentOrTag.map((f) => f.FunctionName)}`,
+    );
+    logger.log(
+      `Functions to uninstrument: ${functionsToUninstrumentOrUntag.map((f) => f.FunctionName)}`,
+    );
+    const batchSize = 50;
+    const batches = createFunctionBatches(
+      functionsToInstrumentOrTag,
+      batchSize,
+    );
+    logger.log(
+      `Processing ${functionsToInstrumentOrTag.length} functions in ${batches.length} batches of ${batchSize}`,
+    );
+
+    for (let i = 0; i < batches.length; i++) {
+      const batch = batches[i];
+      logger.log(
+        `Processing batch ${i + 1}/${batches.length} with ${batch.length} functions`,
+      );
+
+      // First, tag all functions in this batch that need tagging
+      const functionsToTagInBatch = batch.filter((func) => func.needsTagging);
+
+      await tagResourcesWithSlsTag(
+        taggingClient,
+        functionsToTagInBatch.map((f) => f.FunctionArn),
+      );
+
+      // Then, instrument all functions in this batch that need instrumentation
+      const functionsToInstrumentInBatch = batch.filter(
+        (func) => func.needsInstrumentation,
+      );
+      for (const functionToInstrument of functionsToInstrumentInBatch) {
+        await instrumentWithDatadogCi(
+          functionToInstrument,
+          true,
+          config,
+          instrumentOutcome,
+        );
+      }
     }
 
-    // Uninstrument and untag the functions that need to be uninstrumented
-    for (const functionToUninstrument of functionsToUninstrument) {
-      await instrumentWithDatadogCi(
-        functionToUninstrument,
-        false,
-        config,
-        instrumentOutcome,
+    const unprocessBatches = createFunctionBatches(
+      functionsToUninstrumentOrUntag,
+    );
+    logger.log(
+      `Unprocessing ${functionsToUninstrumentOrUntag.length} functions in ${unprocessBatches.length} batches of 20`,
+    );
+
+    for (let i = 0; i < unprocessBatches.length; i++) {
+      const batch = unprocessBatches[i];
+      logger.log(
+        `Unprocessing batch ${i + 1}/${unprocessBatches.length} with ${batch.length} functions`,
+      );
+
+      // First, uninstrument all functions in this batch that need uninstrumentation
+      const functionsToUninstrumentInBatch = batch.filter(
+        (func) => func.needsUninstrumentation,
+      );
+      for (const functionToUninstrument of functionsToUninstrumentInBatch) {
+        await instrumentWithDatadogCi(
+          functionToUninstrument,
+          false,
+          config,
+          instrumentOutcome,
+        );
+      }
+
+      // Then, untag all functions in this batch that need untagging (but only if uninstrumentation didn't fail)
+      const functionsToUntagInBatch = batch.filter(
+        (func) =>
+          func.needsUntagging &&
+          !(func.FunctionName in instrumentOutcome.uninstrument[FAILED]),
+      );
+
+      await untagResourcesOfSlsTag(
+        taggingClient,
+        functionsToUntagInBatch.map((f) => f.FunctionArn),
       );
     }
-    await untagResourcesOfSlsTag(
-      taggingClient,
-      functionsToUntag.flatMap((f) =>
-        !(f.FunctionName in instrumentOutcome.uninstrument[FAILED])
-          ? f.FunctionArn
-          : [],
-      ),
-    );
     // Add the config apply state to the list
     configApplyStates.push(createApplyStateObject(instrumentOutcome, config));
   }

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -192,18 +192,18 @@ async function instrumentFunctions(
       `Functions to uninstrument: ${functionsToUninstrumentOrUntag.map((f) => f.FunctionName)}`,
     );
     const batchSize = 50;
-    const batches = createFunctionBatches(
+    const instrumentBatches = createFunctionBatches(
       functionsToInstrumentOrTag,
       batchSize,
     );
     logger.log(
-      `Processing ${functionsToInstrumentOrTag.length} functions in ${batches.length} batches of ${batchSize}`,
+      `Instrumenting ${functionsToInstrumentOrTag.length} functions in ${instrumentBatches.length} batches of ${batchSize}`,
     );
 
-    for (let i = 0; i < batches.length; i++) {
-      const batch = batches[i];
+    for (let i = 0; i < instrumentBatches.length; i++) {
+      const batch = instrumentBatches[i];
       logger.log(
-        `Processing batch ${i + 1}/${batches.length} with ${batch.length} functions`,
+        `Instrumenting batch ${i + 1}/${instrumentBatches.length} with ${batch.length} functions`,
       );
 
       // First, tag all functions in this batch that need tagging
@@ -228,17 +228,17 @@ async function instrumentFunctions(
       }
     }
 
-    const unprocessBatches = createFunctionBatches(
+    const uninstrumentBatches = createFunctionBatches(
       functionsToUninstrumentOrUntag,
     );
     logger.log(
-      `Unprocessing ${functionsToUninstrumentOrUntag.length} functions in ${unprocessBatches.length} batches of 20`,
+      `Uninstrumenting ${functionsToUninstrumentOrUntag.length} functions in ${uninstrumentBatches.length} batches of 20`,
     );
 
-    for (let i = 0; i < unprocessBatches.length; i++) {
-      const batch = unprocessBatches[i];
+    for (let i = 0; i < uninstrumentBatches.length; i++) {
+      const batch = uninstrumentBatches[i];
       logger.log(
-        `Unprocessing batch ${i + 1}/${unprocessBatches.length} with ${batch.length} functions`,
+        `Uninstrumenting batch ${i + 1}/${uninstrumentBatches.length} with ${batch.length} functions`,
       );
 
       // First, uninstrument all functions in this batch that need uninstrumentation

--- a/test/functions.test.js
+++ b/test/functions.test.js
@@ -1327,24 +1327,18 @@ describe("filterFunctionsToChangeInstrumentation", () => {
         { key: "foo", values: ["bar"], allow: true, filterType: "tag" },
       ],
     });
-    const {
-      functionsToInstrument,
-      functionsToUninstrument,
-      functionsToTag,
-      functionsToUntag,
-    } = filterFunctionsToChangeInstrumentation(
-      functionsToCheck,
-      config,
-      baseInstrumentOutcome,
-    );
-    expect(functionsToInstrument.length).toBe(1);
-    expect(functionsToInstrument[0].FunctionName).toBe("functionA");
-    expect(functionsToUninstrument.length).toBe(1);
-    expect(functionsToUninstrument[0].FunctionName).toBe("functionB");
-    expect(functionsToTag.length).toBe(1);
-    expect(functionsToTag[0].FunctionName).toBe("functionA");
-    expect(functionsToUntag.length).toBe(1);
-    expect(functionsToUntag[0].FunctionName).toBe("functionB");
+    const { functionsToInstrumentOrTag, functionsToUninstrumentOrUntag } =
+      filterFunctionsToChangeInstrumentation(
+        functionsToCheck,
+        config,
+        baseInstrumentOutcome,
+      );
+    expect(Object.keys(functionsToInstrumentOrTag).length).toBe(1);
+    expect(Object.keys(functionsToUninstrumentOrUntag).length).toBe(1);
+    expect(functionsToInstrumentOrTag[0].needsInstrumentation).toBe(true);
+    expect(functionsToInstrumentOrTag[0].needsTagging).toBe(true);
+    expect(functionsToUninstrumentOrUntag[0].needsUninstrumentation).toBe(true);
+    expect(functionsToUninstrumentOrUntag[0].needsUntagging).toBe(true);
   });
 });
 

--- a/test/instrument.test.js
+++ b/test/instrument.test.js
@@ -377,3 +377,28 @@ describe("removeRemoteInstrumentation", () => {
     expect(applyState.deleteApplyState).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("createFunctionBatches", () => {
+  const functionFoo = {
+    FunctionName: "foo",
+    FunctionArn: "arn:aws:lambda:us-east-2:123456789:function:foo",
+    Runtime: "nodejs18.x",
+    Tags: new Set(["env:prod"]),
+  };
+  test("should create batches of the correct size when the number of functions is greater than the batch size", () => {
+    const functions = Array(100).fill(functionFoo);
+    expect(instrument.createFunctionBatches(functions, 50).length).toBe(2);
+    expect(instrument.createFunctionBatches(functions, 50)[0].length).toBe(50);
+    expect(instrument.createFunctionBatches(functions, 50)[1].length).toBe(50);
+  });
+  test("should create a single batch if the number of functions is less than the batch size", () => {
+    const functions = Array(50).fill(functionFoo);
+    expect(instrument.createFunctionBatches(functions, 50).length).toBe(1);
+    expect(instrument.createFunctionBatches(functions, 50)[0].length).toBe(50);
+  });
+  test("should create a single batch if the number of functions is equal to the batch size", () => {
+    const functions = Array(50).fill(functionFoo);
+    expect(instrument.createFunctionBatches(functions, 50).length).toBe(1);
+    expect(instrument.createFunctionBatches(functions, 50)[0].length).toBe(50);
+  });
+});


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Current behavior:
- Tag all functions that need to be tagged
- Instrument all functions that need to be instrumented
- Uninstrument all functions that need to be uninstrumented
- Untag all functions that need to be untagged

New behavior:
- Break functions into batches of 50
- For each batch:
  - Tag functions  in the batch that need to be tagged
  - Instrument functions  in the batch that need to be instrumented
  - Uninstrument functions  in the batch that need to be uninstrumented
  - Untag functions  in the batch that need to be untagged

### Motivation

<!--- What inspired you to submit this pull request? --->

In accounts with a lot of functions, instrumenting all the functions directly one after another quickly exhausts API rate limits, then errors start being written to s3 to retry later and those rate limits get exhausted too. In these cases, we take a long time to self-correct and make progress instrumenting functions. Hopefully, processing in batches will allow us to make more progress.

### Testing Guidelines

- Unit tests
- Bumped up number of functions in tagging integration test to be above batch size. This does add ~40 seconds to the test, so open to suggestions.

### Additional Notes
- We still have batching logic within the tagging functionality (to comply with the hard limit of 20 resources at a time). I kept that in place since it serves a different purpose.
- Batch size of 50 was chosen somewhat arbitrarily.
