### PR TITLE
[SVLS-7855] Support targeting functions by runtime

### DIFF
--- a/integration-tests/lambda-management-events.test.js
+++ b/integration-tests/lambda-management-events.test.js
@@ -121,6 +121,40 @@ describe("Remote instrumenter lambda management event tests", () => {
     expect(isUninstrumented).toStrictEqual(true);
   });
 
+  it("can instrument a lambda function by its runtime", async () => {
+    // When there are two lambdas created with different runtimes
+    const { FunctionName: nodejsFunctionName } = await createFunction({
+      Runtime: "nodejs20.x",
+    });
+    const { FunctionName: pythonFunctionName } = await createFunction({
+      Runtime: "python3.10",
+    });
+
+    // And the config targets functions by runtime
+    await setRemoteConfig({
+      ruleFilters: [
+        {
+          key: "runtime",
+          values: ["nodejs20.x"],
+          filter_type: "tag",
+          allow: true,
+        },
+      ],
+    });
+
+    // After some time
+    const areCorrectlyInstrumented = await pollUntilTrue(
+      60000,
+      5000,
+      () =>
+        isFunctionInstrumented(nodejsFunctionName) &&
+        isFunctionUninstrumented(pythonFunctionName),
+    );
+
+    // The functions are instrumented and uninstrumented respectively
+    expect(areCorrectlyInstrumented).toStrictEqual(true);
+  });
+
   it("can instrument multiple new lambda functions", async () => {
     // When there is a remote config
     await setRemoteConfig();

--- a/src/functions.js
+++ b/src/functions.js
@@ -131,6 +131,10 @@ async function enrichFunctionsWithTags(client, functions) {
     for (const [key, value] of Object.entries(awsResourceTags)) {
       functionTags.push(key + ":" + value);
     }
+
+    // Also add the runtime as a tag
+    functionTags.push("runtime:" + lambdaFunc.Runtime);
+
     const functionTagsSet = new Set(functionTags);
     lambdaFunc.Tags = functionTagsSet;
     enrichedFunctions.push(lambdaFunc);

--- a/test/functions.test.js
+++ b/test/functions.test.js
@@ -7,6 +7,7 @@ const {
   isInstrumented,
   waitUntilFunctionIsActive,
   selectFunctionFieldsForLogging,
+  enrichFunctionsWithTags,
 } = require("../src/functions");
 const {
   DD_SLS_REMOTE_INSTRUMENTER_VERSION,
@@ -1469,5 +1470,155 @@ describe("selectFunctionFieldsForLogging", () => {
       Tags: Array.from(lambdaFunc.Tags),
       Layers: lambdaFunc.Layers,
     });
+  });
+});
+
+describe("enrichFunctionsWithTags", () => {
+  let mockClient;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockClient = {
+      send: jest.fn(),
+    };
+  });
+
+  test("should include tags from DD_TAGS env var, AWS resource tags, and runtime", async () => {
+    const functions = [
+      createTestLambdaFunction({
+        functionName: "functionA",
+        functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
+        runtime: "nodejs14.x",
+        tags: { env: "prod", team: "backend" },
+        layers: [],
+        envVars: {
+          DD_TAGS: "service:api version:1.0.0",
+        },
+      }),
+      createTestLambdaFunction({
+        functionName: "functionB",
+        functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionB",
+        runtime: "python3.8",
+        tags: { env: "staging", team: "frontend" },
+        layers: [],
+        envVars: {},
+      }),
+    ];
+
+    const enrichedFunctions = await enrichFunctionsWithTags(
+      mockClient,
+      functions,
+    );
+
+    expect(enrichedFunctions[0].Tags).toEqual(
+      new Set([
+        "service:api",
+        "version:1.0.0",
+        "env:prod",
+        "team:backend",
+        "runtime:nodejs14.x",
+      ]),
+    );
+    expect(enrichedFunctions[1].Tags).toEqual(
+      new Set(["env:staging", "team:frontend", "runtime:python3.8"]),
+    );
+  });
+
+  test("should fetch AWS resource tags when Tags property is not present", async () => {
+    const functions = [
+      createTestLambdaFunction({
+        functionName: "functionA",
+        functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
+        runtime: "nodejs14.x",
+        layers: [],
+        envVars: {},
+      }),
+    ];
+
+    mockClient.send.mockResolvedValue({
+      Tags: {
+        env: "staging",
+        owner: "devops",
+      },
+    });
+
+    const enrichedFunctions = await enrichFunctionsWithTags(
+      mockClient,
+      functions,
+    );
+
+    expect(enrichedFunctions[0].Tags).toEqual(
+      new Set(["env:staging", "owner:devops", "runtime:nodejs14.x"]),
+    );
+  });
+
+  test("should not fetch AWS resource tags when Tags property is already present", async () => {
+    const functions = [
+      createTestLambdaFunction({
+        functionName: "functionA",
+        functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
+        runtime: "nodejs14.x",
+        tags: { env: "prod" },
+        layers: [],
+        envVars: {},
+      }),
+    ];
+
+    const enrichedFunctions = await enrichFunctionsWithTags(
+      mockClient,
+      functions,
+    );
+
+    expect(mockClient.send).not.toHaveBeenCalled();
+    expect(enrichedFunctions[0].Tags).toEqual(
+      new Set(["env:prod", "runtime:nodejs14.x"]),
+    );
+  });
+
+  test("should deduplicate tags correctly", async () => {
+    const functions = [
+      createTestLambdaFunction({
+        functionName: "functionA",
+        functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
+        runtime: "nodejs14.x",
+        tags: { env: "prod", service: "api" },
+        layers: [],
+        envVars: {
+          DD_TAGS: "env:prod service:web",
+        },
+      }),
+    ];
+
+    const enrichedFunctions = await enrichFunctionsWithTags(
+      mockClient,
+      functions,
+    );
+
+    // env:prod should appear only once, service:api and service:web should both appear
+    expect(enrichedFunctions[0].Tags).toEqual(
+      new Set(["env:prod", "service:api", "service:web", "runtime:nodejs14.x"]),
+    );
+  });
+
+  test("should handle AWS resource tags with empty object", async () => {
+    const functions = [
+      createTestLambdaFunction({
+        functionName: "functionA",
+        functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
+        runtime: "nodejs14.x",
+        layers: [],
+        envVars: {},
+      }),
+    ];
+
+    mockClient.send.mockResolvedValue({
+      Tags: {},
+    });
+
+    const enrichedFunctions = await enrichFunctionsWithTags(
+      mockClient,
+      functions,
+    );
+    expect(enrichedFunctions[0].Tags).toEqual(new Set(["runtime:nodejs14.x"]));
   });
 });


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR updates the remote instrumenter to support targeting functions by their runtime. It does this by taking the `Runtime` field off of each function in the `ListFunctions` response, and adding `runtime:<the-function-runtime>` to each function's enriched tag set. 

### Motivation

<!--- What inspired you to submit this pull request? --->

Users should be able to target functions by runtime. They can already select `runtime` as a tag in the UI, but the instrumenter also needs to support it.

### Testing Guidelines

<!--- How did you test this pull request? --->

- Unit tests for `enrichFunctionsWithTags`
- Integration test for targeting by runtime

### Additional Notes

<!--- Anything else we should know when reviewing? --->
