### PR TITLE
Release v2.0.0

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -5,7 +5,7 @@ Description: Datadog Lambda Remote Instrumentation App
 Mappings:
   Constants:
     DdRemoteInstrumentApp:
-      Version: 1.10.0
+      Version: 2.0.0
     DdRemoteInstrumentLayerAwsAccount:
       Number: 464622532012
     InstrumenterFunctionName:


### PR DESCRIPTION

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

This PR releases v2.0.0 of remote instrumentation. Changes in this release include:
- Converting the codebase to typescript
- Using datadog-ci library functions instead of running it as a CLI command
- Support for targeting functions by runtime (e.g. `runtime:python3.14`)
- Support for instrumenting functions of any runtime (not just Node.js and Python runtimes)

**⚠️ Warning (major version bump):**
This final of these changes is a breaking change - upon upgrading to this version of the remote instrumentation stack, any pre-configured rules (e.g. instrument all functions with tag `service:foo`) will cover not only Node.js and Python functions, but functions of any runtime that are tagged `service:foo`, which would have previously been skipped. This may have billing implications as more functions may be instrumented with the Datadog Extension than before.

**This release includes the following commits:**
91bd7d8 Fix exports
9df7093 Run linter
d2cd57e [SVLS-7727] use datadog-ci as a library (#213) fcdd715 [SVLS-7935] convert to typescript (#211)
adfe778 Support filtering by runtime
06e88d9 Fix tests
d9e2941 Fix config
4f816f1 Update supported runtimes

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->


[SVLS-7727]: https://datadoghq.atlassian.net/browse/SVLS-7727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ