### PR TITLE
Add Serverless Remote Instrumentation support for AWS SSM API Key

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -123,6 +123,7 @@ export const DD_SERVERLESS_LOGS_ENABLED = "DD_SERVERLESS_LOGS_ENABLED";
 export const DD_API_KEY = "DD_API_KEY";
 export const DD_KMS_API_KEY = "DD_KMS_API_KEY";
 export const DD_API_KEY_SECRET_ARN = "DD_API_KEY_SECRET_ARN";
+export const DD_API_KEY_SSM_ARN = "DD_API_KEY_SSM_ARN";
 export const DD_SITE = "DD_SITE";
 
 // Remote config constants

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -14,6 +14,7 @@ import {
   DD_API_KEY,
   DD_KMS_API_KEY,
   DD_API_KEY_SECRET_ARN,
+  DD_API_KEY_SSM_ARN,
   DD_SITE,
   VERSION,
   INSTRUMENT,
@@ -286,6 +287,7 @@ export function isInstrumented(lambdaFunc: LambdaFunction): boolean {
   if (
     (envVars.has(DD_API_KEY) ||
       envVars.has(DD_API_KEY_SECRET_ARN) ||
+      envVars.has(DD_API_KEY_SSM_ARN) ||
       envVars.has(DD_KMS_API_KEY)) &&
     envVars.has(DD_SITE)
   ) {

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -1430,7 +1430,8 @@ describe("isInstrumented", () => {
       {
         Environment: {
           Variables: {
-            DD_API_KEY_SECRET_ARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:dd-api-key",
+            DD_API_KEY_SECRET_ARN:
+              "arn:aws:secretsmanager:us-east-1:123456789012:secret:dd-api-key",
             DD_SITE: "datadoghq.com",
           },
         },
@@ -1442,7 +1443,8 @@ describe("isInstrumented", () => {
       {
         Environment: {
           Variables: {
-            DD_API_KEY_SSM_ARN: "arn:aws:ssm:us-east-2:425362996713:parameter/dev/DD_API_KEY",
+            DD_API_KEY_SSM_ARN:
+              "arn:aws:ssm:us-east-2:425362996713:parameter/dev/DD_API_KEY",
             DD_SITE: "datadoghq.com",
           },
         },

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -1426,6 +1426,42 @@ describe("isInstrumented", () => {
       false,
     ],
     [
+      "Is instrumented with DD_API_KEY_SECRET_ARN and DD_SITE",
+      {
+        Environment: {
+          Variables: {
+            DD_API_KEY_SECRET_ARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:dd-api-key",
+            DD_SITE: "datadoghq.com",
+          },
+        },
+      },
+      true,
+    ],
+    [
+      "Is instrumented with DD_API_KEY_SSM_ARN and DD_SITE",
+      {
+        Environment: {
+          Variables: {
+            DD_API_KEY_SSM_ARN: "arn:aws:ssm:us-east-2:425362996713:parameter/dev/DD_API_KEY",
+            DD_SITE: "datadoghq.com",
+          },
+        },
+      },
+      true,
+    ],
+    [
+      "Is instrumented with DD_KMS_API_KEY and DD_SITE",
+      {
+        Environment: {
+          Variables: {
+            DD_KMS_API_KEY: "encrypted-key",
+            DD_SITE: "datadoghq.com",
+          },
+        },
+      },
+      true,
+    ],
+    [
       "Has datadog layers, others potentially configured in yaml",
       {
         Layers: [


### PR DESCRIPTION
### What and why?
Add DD_API_KEY_SSM_ARN env var to Serverless Remote Instrumentation to support AWS SSM Parameter ARN (e.g., `arn:aws:ssm:region:account:parameter/path`) to use a SecretString you must set `ssm:GetParameter` and `kms:Decrypt` (for encrypted SecureString parameters) IAM Permissions

### How?
[Link to example lambda deploy ](https://us-east-2.console.aws.amazon.com/lambda/home?region=us-east-2#/functions/test-sls-instru-ssm-dev?tab=testing) and [example trace](https://app.datadoghq.com/apm/trace/69740469000000001d970aaa0a256386?graphType=service_map&shouldShowLegend=true&spanID=5010515275176300409&timeHint=1769210984845&trace=69740469000000001d970aaa0a2563865010515275176300409&traceQuery=)

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->
