### PR TITLE
Add test123.prod.dog datacenter support

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -58,7 +58,7 @@ Parameters:
     Type: String
     Default: datadoghq.com
     Description: >-
-      The Datadog site where data will be sent. Possible values are `datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`.
+      The Datadog site where data will be sent. Possible values are `datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`, `ddog-gov.com`, `test123.prod.dog`.
     AllowedPattern: .+
     ConstraintDescription: DdSite is required
   BucketName:


### PR DESCRIPTION
This PR adds support for the new test123.prod.dog datacenter to the DdSite parameter description.