### PR TITLE
Release v2.2.0

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -5,7 +5,7 @@ Description: Datadog Lambda Remote Instrumentation App
 Mappings:
   Constants:
     DdRemoteInstrumentApp:
-      Version: 2.1.0
+      Version: 2.2.0
     DdRemoteInstrumentLayerAwsAccount:
       Number: 464622532012
     InstrumenterFunctionName:


### PR DESCRIPTION


### What does this PR do?

This PR release v2.2.0 of remote instrumentation. Changes in this PR include:
- Support for instrumenting lambdas with additional runtimes (e.g. .NET 10)
- Consider lambdas with DD_API_KEY_SSM_ARN to be instrumented

This release includes the following commits:
2c6bc0f update from linter
080e0fd Support DD_API_KEY_SSM_ARN
c27e7fa Fix unit tests
0c93865 Fix typecheck
8bb858b Bump datadog-ci version and improve integration tests f8544ef [SVLS-8266] migrate to serverless onboarding managed team (#221) 235d694 [CHORE] add pre-commit config (#219)
674592d [CHORE] fix type check (#220)
1f79a3e [CHORE] fix undefined runtime (#218)

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->


[SVLS-8266]: https://datadoghq.atlassian.net/browse/SVLS-8266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ