### PR TITLE
chore: cdk acknowledge 34892

### DIFF
--- a/cdk.context.json
+++ b/cdk.context.json
@@ -1,0 +1,5 @@
+{
+  "acknowledged-issue-numbers": [
+    34892
+  ]
+}


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

No more of this:

```
NOTICES         (What's this? https://github.com/aws/aws-cdk/wiki/CLI-Notices)

34892	CDK CLI collects telemetry data on command usage starting at version 2.1100.0 (unless opted out)

	Overview: We do not collect customer content and we anonymize the
	          telemetry we do collect. See the attached issue for more
	          information on what data is collected, why, and how to
	          opt-out. Telemetry will NOT be collected for any CDK CLI
	          version prior to version 2.1100.0 - regardless of
	          opt-in/out. You can also view the telemetry we collect by
	          logging it to a local file, by adding
	          `--telemetry-file=my/local/file` to any `cdk` command.

	Affected versions: cli: >=2.1100.0 <2.1106.1

	More information at: https://github.com/aws/aws-cdk/issues/34892


If you don’t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 34892".
```

<!--- A brief description of the change being made with this pull request. --->

### Motivation

Its annoying

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->