### PR TITLE
Pin @datadog/datadog-ci-* to 5.11.0 and axios to 1.13.5 exactly

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "license": "Apache-2.0",
   "type": "module",
   "dependencies": {
-    "@datadog/datadog-ci-base": "^5.9.1",
-    "@datadog/datadog-ci-plugin-lambda": "^5.9.1",
-    "axios": "^1.13.6"
+    "@datadog/datadog-ci-base": "5.11.0",
+    "@datadog/datadog-ci-plugin-lambda": "5.11.0",
+    "axios": "1.13.5"
   },
   "devDependencies": {
     "@aws-sdk/client-cloudwatch-logs": "~3.990.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,7 +5,7 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@antfu/install-pkg@npm:^1.1.0":
+"@antfu/install-pkg@npm:1.1.0":
   version: 1.1.0
   resolution: "@antfu/install-pkg@npm:1.1.0"
   dependencies:
@@ -133,7 +133,57 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-cloudwatch-logs@npm:^3.981.0, @aws-sdk/client-cloudwatch-logs@npm:~3.990.0":
+"@aws-sdk/client-cloudwatch-logs@npm:3.981.0":
+  version: 3.981.0
+  resolution: "@aws-sdk/client-cloudwatch-logs@npm:3.981.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.973.5"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.4"
+    "@aws-sdk/middleware-host-header": "npm:^3.972.3"
+    "@aws-sdk/middleware-logger": "npm:^3.972.3"
+    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.3"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.5"
+    "@aws-sdk/region-config-resolver": "npm:^3.972.3"
+    "@aws-sdk/types": "npm:^3.973.1"
+    "@aws-sdk/util-endpoints": "npm:3.981.0"
+    "@aws-sdk/util-user-agent-browser": "npm:^3.972.3"
+    "@aws-sdk/util-user-agent-node": "npm:^3.972.3"
+    "@smithy/config-resolver": "npm:^4.4.6"
+    "@smithy/core": "npm:^3.22.0"
+    "@smithy/eventstream-serde-browser": "npm:^4.2.8"
+    "@smithy/eventstream-serde-config-resolver": "npm:^4.3.8"
+    "@smithy/eventstream-serde-node": "npm:^4.2.8"
+    "@smithy/fetch-http-handler": "npm:^5.3.9"
+    "@smithy/hash-node": "npm:^4.2.8"
+    "@smithy/invalid-dependency": "npm:^4.2.8"
+    "@smithy/middleware-content-length": "npm:^4.2.8"
+    "@smithy/middleware-endpoint": "npm:^4.4.12"
+    "@smithy/middleware-retry": "npm:^4.4.29"
+    "@smithy/middleware-serde": "npm:^4.2.9"
+    "@smithy/middleware-stack": "npm:^4.2.8"
+    "@smithy/node-config-provider": "npm:^4.3.8"
+    "@smithy/node-http-handler": "npm:^4.4.8"
+    "@smithy/protocol-http": "npm:^5.3.8"
+    "@smithy/smithy-client": "npm:^4.11.1"
+    "@smithy/types": "npm:^4.12.0"
+    "@smithy/url-parser": "npm:^4.2.8"
+    "@smithy/util-base64": "npm:^4.3.0"
+    "@smithy/util-body-length-browser": "npm:^4.2.0"
+    "@smithy/util-body-length-node": "npm:^4.2.1"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.28"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.31"
+    "@smithy/util-endpoints": "npm:^3.2.8"
+    "@smithy/util-middleware": "npm:^4.2.8"
+    "@smithy/util-retry": "npm:^4.2.8"
+    "@smithy/util-utf8": "npm:^4.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/5327e77a304744781ccd7f6947bdc3d4e754706c98c65605d3700c9c9e5858a97689b7e314f13652ebd01592b630bb5f957e3654f178a7725d04ac72d2735ea0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-cloudwatch-logs@npm:~3.990.0":
   version: 3.990.0
   resolution: "@aws-sdk/client-cloudwatch-logs@npm:3.990.0"
   dependencies:
@@ -230,102 +280,154 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-cognito-identity@npm:3.990.0":
-  version: 3.990.0
-  resolution: "@aws-sdk/client-cognito-identity@npm:3.990.0"
+"@aws-sdk/client-cognito-identity@npm:3.981.0":
+  version: 3.981.0
+  resolution: "@aws-sdk/client-cognito-identity@npm:3.981.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:^3.973.10"
-    "@aws-sdk/credential-provider-node": "npm:^3.972.9"
+    "@aws-sdk/core": "npm:^3.973.5"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.4"
     "@aws-sdk/middleware-host-header": "npm:^3.972.3"
     "@aws-sdk/middleware-logger": "npm:^3.972.3"
     "@aws-sdk/middleware-recursion-detection": "npm:^3.972.3"
-    "@aws-sdk/middleware-user-agent": "npm:^3.972.10"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.5"
     "@aws-sdk/region-config-resolver": "npm:^3.972.3"
     "@aws-sdk/types": "npm:^3.973.1"
-    "@aws-sdk/util-endpoints": "npm:3.990.0"
+    "@aws-sdk/util-endpoints": "npm:3.981.0"
     "@aws-sdk/util-user-agent-browser": "npm:^3.972.3"
-    "@aws-sdk/util-user-agent-node": "npm:^3.972.8"
+    "@aws-sdk/util-user-agent-node": "npm:^3.972.3"
     "@smithy/config-resolver": "npm:^4.4.6"
-    "@smithy/core": "npm:^3.23.0"
+    "@smithy/core": "npm:^3.22.0"
     "@smithy/fetch-http-handler": "npm:^5.3.9"
     "@smithy/hash-node": "npm:^4.2.8"
     "@smithy/invalid-dependency": "npm:^4.2.8"
     "@smithy/middleware-content-length": "npm:^4.2.8"
-    "@smithy/middleware-endpoint": "npm:^4.4.14"
-    "@smithy/middleware-retry": "npm:^4.4.31"
+    "@smithy/middleware-endpoint": "npm:^4.4.12"
+    "@smithy/middleware-retry": "npm:^4.4.29"
     "@smithy/middleware-serde": "npm:^4.2.9"
     "@smithy/middleware-stack": "npm:^4.2.8"
     "@smithy/node-config-provider": "npm:^4.3.8"
-    "@smithy/node-http-handler": "npm:^4.4.10"
+    "@smithy/node-http-handler": "npm:^4.4.8"
     "@smithy/protocol-http": "npm:^5.3.8"
-    "@smithy/smithy-client": "npm:^4.11.3"
+    "@smithy/smithy-client": "npm:^4.11.1"
     "@smithy/types": "npm:^4.12.0"
     "@smithy/url-parser": "npm:^4.2.8"
     "@smithy/util-base64": "npm:^4.3.0"
     "@smithy/util-body-length-browser": "npm:^4.2.0"
     "@smithy/util-body-length-node": "npm:^4.2.1"
-    "@smithy/util-defaults-mode-browser": "npm:^4.3.30"
-    "@smithy/util-defaults-mode-node": "npm:^4.2.33"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.28"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.31"
     "@smithy/util-endpoints": "npm:^3.2.8"
     "@smithy/util-middleware": "npm:^4.2.8"
     "@smithy/util-retry": "npm:^4.2.8"
     "@smithy/util-utf8": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/5d094392e147bc4fad5df17e3d59da62f5c585122a9b6172af4e8ea52661b2e9269fc6bab1657fe4c18f72de8087e939316fdf3576a627e4bee98390ad735da6
+  checksum: 10c0/89475fbd84946d8f4087bf087f4b05aca33ca7348bb37071b309deaaf021e6bf5d517169bc5ece21a9968460059818cd10555427bbecf11ced4fcd22219318ae
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-iam@npm:^3.981.0":
-  version: 3.1012.0
-  resolution: "@aws-sdk/client-iam@npm:3.1012.0"
+"@aws-sdk/client-iam@npm:3.981.0":
+  version: 3.981.0
+  resolution: "@aws-sdk/client-iam@npm:3.981.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:^3.973.21"
-    "@aws-sdk/credential-provider-node": "npm:^3.972.22"
-    "@aws-sdk/middleware-host-header": "npm:^3.972.8"
-    "@aws-sdk/middleware-logger": "npm:^3.972.8"
-    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.8"
-    "@aws-sdk/middleware-user-agent": "npm:^3.972.22"
-    "@aws-sdk/region-config-resolver": "npm:^3.972.8"
-    "@aws-sdk/types": "npm:^3.973.6"
-    "@aws-sdk/util-endpoints": "npm:^3.996.5"
-    "@aws-sdk/util-user-agent-browser": "npm:^3.972.8"
-    "@aws-sdk/util-user-agent-node": "npm:^3.973.8"
-    "@smithy/config-resolver": "npm:^4.4.11"
-    "@smithy/core": "npm:^3.23.12"
-    "@smithy/fetch-http-handler": "npm:^5.3.15"
-    "@smithy/hash-node": "npm:^4.2.12"
-    "@smithy/invalid-dependency": "npm:^4.2.12"
-    "@smithy/middleware-content-length": "npm:^4.2.12"
-    "@smithy/middleware-endpoint": "npm:^4.4.26"
-    "@smithy/middleware-retry": "npm:^4.4.43"
-    "@smithy/middleware-serde": "npm:^4.2.15"
-    "@smithy/middleware-stack": "npm:^4.2.12"
-    "@smithy/node-config-provider": "npm:^4.3.12"
-    "@smithy/node-http-handler": "npm:^4.5.0"
-    "@smithy/protocol-http": "npm:^5.3.12"
-    "@smithy/smithy-client": "npm:^4.12.6"
-    "@smithy/types": "npm:^4.13.1"
-    "@smithy/url-parser": "npm:^4.2.12"
-    "@smithy/util-base64": "npm:^4.3.2"
-    "@smithy/util-body-length-browser": "npm:^4.2.2"
-    "@smithy/util-body-length-node": "npm:^4.2.3"
-    "@smithy/util-defaults-mode-browser": "npm:^4.3.42"
-    "@smithy/util-defaults-mode-node": "npm:^4.2.45"
-    "@smithy/util-endpoints": "npm:^3.3.3"
-    "@smithy/util-middleware": "npm:^4.2.12"
-    "@smithy/util-retry": "npm:^4.2.12"
-    "@smithy/util-utf8": "npm:^4.2.2"
-    "@smithy/util-waiter": "npm:^4.2.13"
+    "@aws-sdk/core": "npm:^3.973.5"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.4"
+    "@aws-sdk/middleware-host-header": "npm:^3.972.3"
+    "@aws-sdk/middleware-logger": "npm:^3.972.3"
+    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.3"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.5"
+    "@aws-sdk/region-config-resolver": "npm:^3.972.3"
+    "@aws-sdk/types": "npm:^3.973.1"
+    "@aws-sdk/util-endpoints": "npm:3.981.0"
+    "@aws-sdk/util-user-agent-browser": "npm:^3.972.3"
+    "@aws-sdk/util-user-agent-node": "npm:^3.972.3"
+    "@smithy/config-resolver": "npm:^4.4.6"
+    "@smithy/core": "npm:^3.22.0"
+    "@smithy/fetch-http-handler": "npm:^5.3.9"
+    "@smithy/hash-node": "npm:^4.2.8"
+    "@smithy/invalid-dependency": "npm:^4.2.8"
+    "@smithy/middleware-content-length": "npm:^4.2.8"
+    "@smithy/middleware-endpoint": "npm:^4.4.12"
+    "@smithy/middleware-retry": "npm:^4.4.29"
+    "@smithy/middleware-serde": "npm:^4.2.9"
+    "@smithy/middleware-stack": "npm:^4.2.8"
+    "@smithy/node-config-provider": "npm:^4.3.8"
+    "@smithy/node-http-handler": "npm:^4.4.8"
+    "@smithy/protocol-http": "npm:^5.3.8"
+    "@smithy/smithy-client": "npm:^4.11.1"
+    "@smithy/types": "npm:^4.12.0"
+    "@smithy/url-parser": "npm:^4.2.8"
+    "@smithy/util-base64": "npm:^4.3.0"
+    "@smithy/util-body-length-browser": "npm:^4.2.0"
+    "@smithy/util-body-length-node": "npm:^4.2.1"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.28"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.31"
+    "@smithy/util-endpoints": "npm:^3.2.8"
+    "@smithy/util-middleware": "npm:^4.2.8"
+    "@smithy/util-retry": "npm:^4.2.8"
+    "@smithy/util-utf8": "npm:^4.2.0"
+    "@smithy/util-waiter": "npm:^4.2.8"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/0a4421e7ad4f35ac3fabb562d8c3662ee44c78a38d34aad11b3c04cf2fe6b7d3598c4ee89f53a8ac5781538a9c594b587dc7306d075704cc19be9f3c450c905a
+  checksum: 10c0/40179b81aa11c4516db635927acff90236e0fd63fe8c891b44a2774213be1f4ddec736df1ca56bfcefc8b6d91f7219911706a5b12342981dcc2f9e34f8496e19
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-lambda@npm:^3.981.0, @aws-sdk/client-lambda@npm:~3.990.0":
+"@aws-sdk/client-lambda@npm:3.981.0":
+  version: 3.981.0
+  resolution: "@aws-sdk/client-lambda@npm:3.981.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.973.5"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.4"
+    "@aws-sdk/middleware-host-header": "npm:^3.972.3"
+    "@aws-sdk/middleware-logger": "npm:^3.972.3"
+    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.3"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.5"
+    "@aws-sdk/region-config-resolver": "npm:^3.972.3"
+    "@aws-sdk/types": "npm:^3.973.1"
+    "@aws-sdk/util-endpoints": "npm:3.981.0"
+    "@aws-sdk/util-user-agent-browser": "npm:^3.972.3"
+    "@aws-sdk/util-user-agent-node": "npm:^3.972.3"
+    "@smithy/config-resolver": "npm:^4.4.6"
+    "@smithy/core": "npm:^3.22.0"
+    "@smithy/eventstream-serde-browser": "npm:^4.2.8"
+    "@smithy/eventstream-serde-config-resolver": "npm:^4.3.8"
+    "@smithy/eventstream-serde-node": "npm:^4.2.8"
+    "@smithy/fetch-http-handler": "npm:^5.3.9"
+    "@smithy/hash-node": "npm:^4.2.8"
+    "@smithy/invalid-dependency": "npm:^4.2.8"
+    "@smithy/middleware-content-length": "npm:^4.2.8"
+    "@smithy/middleware-endpoint": "npm:^4.4.12"
+    "@smithy/middleware-retry": "npm:^4.4.29"
+    "@smithy/middleware-serde": "npm:^4.2.9"
+    "@smithy/middleware-stack": "npm:^4.2.8"
+    "@smithy/node-config-provider": "npm:^4.3.8"
+    "@smithy/node-http-handler": "npm:^4.4.8"
+    "@smithy/protocol-http": "npm:^5.3.8"
+    "@smithy/smithy-client": "npm:^4.11.1"
+    "@smithy/types": "npm:^4.12.0"
+    "@smithy/url-parser": "npm:^4.2.8"
+    "@smithy/util-base64": "npm:^4.3.0"
+    "@smithy/util-body-length-browser": "npm:^4.2.0"
+    "@smithy/util-body-length-node": "npm:^4.2.1"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.28"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.31"
+    "@smithy/util-endpoints": "npm:^3.2.8"
+    "@smithy/util-middleware": "npm:^4.2.8"
+    "@smithy/util-retry": "npm:^4.2.8"
+    "@smithy/util-stream": "npm:^4.5.10"
+    "@smithy/util-utf8": "npm:^4.2.0"
+    "@smithy/util-waiter": "npm:^4.2.8"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/d3ce4637f2664d5da26580d59d38176d067d38e541b6050825dd3e463b5ea63660afe36a8c66282734554933b117e000c29c549a5a3a066c3e761d2dbbac46dd
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-lambda@npm:~3.990.0":
   version: 3.990.0
   resolution: "@aws-sdk/client-lambda@npm:3.990.0"
   dependencies:
@@ -622,6 +724,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/core@npm:^3.973.26":
+  version: 3.973.26
+  resolution: "@aws-sdk/core@npm:3.973.26"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.6"
+    "@aws-sdk/xml-builder": "npm:^3.972.16"
+    "@smithy/core": "npm:^3.23.13"
+    "@smithy/node-config-provider": "npm:^4.3.12"
+    "@smithy/property-provider": "npm:^4.2.12"
+    "@smithy/protocol-http": "npm:^5.3.12"
+    "@smithy/signature-v4": "npm:^5.3.12"
+    "@smithy/smithy-client": "npm:^4.12.8"
+    "@smithy/types": "npm:^4.13.1"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-middleware": "npm:^4.2.12"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e3f7517b3c6d5e3a7cf12f812ba319f657e200b605682e8a50f89bf1f78fc1cb018a08b9c91517d86dc9de6560c24bc18a7d8902a6744a1fe98f72ad41cab430
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/crc64-nvme@npm:^3.972.5":
   version: 3.972.5
   resolution: "@aws-sdk/crc64-nvme@npm:3.972.5"
@@ -645,16 +768,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:^3.972.19":
-  version: 3.972.19
-  resolution: "@aws-sdk/credential-provider-env@npm:3.972.19"
+"@aws-sdk/credential-provider-env@npm:^3.972.24, @aws-sdk/credential-provider-env@npm:^3.972.3":
+  version: 3.972.24
+  resolution: "@aws-sdk/credential-provider-env@npm:3.972.24"
   dependencies:
-    "@aws-sdk/core": "npm:^3.973.21"
+    "@aws-sdk/core": "npm:^3.973.26"
     "@aws-sdk/types": "npm:^3.973.6"
     "@smithy/property-provider": "npm:^4.2.12"
     "@smithy/types": "npm:^4.13.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/a064b43c75ff2431ca21ff4376521ec663cfc5fa5b0b30804c785284cff6a2be3def093ee446e3c0b033b19f73aa338f70b847bf210ecc84698c10e8604f339b
+  checksum: 10c0/bac713a6d4ca4e36c8fd783dad61b9ee279f10bf0a22c57c2f7c906735ebfadf0da951569ad14739a1b1eff4dbe1bce7afc7dbde03066a6a2b1870da81bf56d3
   languageName: node
   linkType: hard
 
@@ -689,43 +812,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-http@npm:^3.972.21":
-  version: 3.972.21
-  resolution: "@aws-sdk/credential-provider-http@npm:3.972.21"
+"@aws-sdk/credential-provider-http@npm:^3.972.26, @aws-sdk/credential-provider-http@npm:^3.972.5":
+  version: 3.972.26
+  resolution: "@aws-sdk/credential-provider-http@npm:3.972.26"
   dependencies:
-    "@aws-sdk/core": "npm:^3.973.21"
+    "@aws-sdk/core": "npm:^3.973.26"
     "@aws-sdk/types": "npm:^3.973.6"
     "@smithy/fetch-http-handler": "npm:^5.3.15"
-    "@smithy/node-http-handler": "npm:^4.5.0"
+    "@smithy/node-http-handler": "npm:^4.5.1"
     "@smithy/property-provider": "npm:^4.2.12"
     "@smithy/protocol-http": "npm:^5.3.12"
-    "@smithy/smithy-client": "npm:^4.12.6"
+    "@smithy/smithy-client": "npm:^4.12.8"
     "@smithy/types": "npm:^4.13.1"
-    "@smithy/util-stream": "npm:^4.5.20"
+    "@smithy/util-stream": "npm:^4.5.21"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/4d507c8cf2ac820fa4554cec8e7c3cf483df8d19ae16a4ccc9d58824443439bf3c04b6effc3705938829256ec587beb5251a7772f89e6a59ed319e0754283272
+  checksum: 10c0/d837caa15b8a22112fcdafd2c0c3fc1d22c5be25d6124d1a67900acd4e9c5b44b1101467a936f8ff2c3eaec99ade769d816e12833558572bb8feef98c0e3cff5
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:^3.972.21, @aws-sdk/credential-provider-ini@npm:^3.972.9":
-  version: 3.972.21
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.972.21"
+"@aws-sdk/credential-provider-ini@npm:^3.972.3":
+  version: 3.972.27
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.972.27"
   dependencies:
-    "@aws-sdk/core": "npm:^3.973.21"
-    "@aws-sdk/credential-provider-env": "npm:^3.972.19"
-    "@aws-sdk/credential-provider-http": "npm:^3.972.21"
-    "@aws-sdk/credential-provider-login": "npm:^3.972.21"
-    "@aws-sdk/credential-provider-process": "npm:^3.972.19"
-    "@aws-sdk/credential-provider-sso": "npm:^3.972.21"
-    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.21"
-    "@aws-sdk/nested-clients": "npm:^3.996.11"
+    "@aws-sdk/core": "npm:^3.973.26"
+    "@aws-sdk/credential-provider-env": "npm:^3.972.24"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.26"
+    "@aws-sdk/credential-provider-login": "npm:^3.972.27"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.24"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.27"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.27"
+    "@aws-sdk/nested-clients": "npm:^3.996.17"
     "@aws-sdk/types": "npm:^3.973.6"
     "@smithy/credential-provider-imds": "npm:^4.2.12"
     "@smithy/property-provider": "npm:^4.2.12"
     "@smithy/shared-ini-file-loader": "npm:^4.4.7"
     "@smithy/types": "npm:^4.13.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/3eb168f9e72740a4e5b56c39dec5ce463cceeddc1a8caf3b859198ac95b73f1740def7229bce30dd337bc8132a281fa4e918681f94f96406187a881fd194804a
+  checksum: 10c0/526e381c520023d7933ac28266f8919941ba4aa0a437e90e84ff2992eb0a245bcf4a5aa83cc86f384ca849b8b27c9b204d91d9a7a585fe1d6fd3da4e381157da
   languageName: node
   linkType: hard
 
@@ -751,19 +874,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-login@npm:^3.972.21":
-  version: 3.972.21
-  resolution: "@aws-sdk/credential-provider-login@npm:3.972.21"
+"@aws-sdk/credential-provider-login@npm:^3.972.27, @aws-sdk/credential-provider-login@npm:^3.972.3":
+  version: 3.972.27
+  resolution: "@aws-sdk/credential-provider-login@npm:3.972.27"
   dependencies:
-    "@aws-sdk/core": "npm:^3.973.21"
-    "@aws-sdk/nested-clients": "npm:^3.996.11"
+    "@aws-sdk/core": "npm:^3.973.26"
+    "@aws-sdk/nested-clients": "npm:^3.996.17"
     "@aws-sdk/types": "npm:^3.973.6"
     "@smithy/property-provider": "npm:^4.2.12"
     "@smithy/protocol-http": "npm:^5.3.12"
     "@smithy/shared-ini-file-loader": "npm:^4.4.7"
     "@smithy/types": "npm:^4.13.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/79b267a812aee3b0e2f0857d23eb544ac65c6dd23bffb4c2e09f5d2b5be9575ccb7b0fd5d395735412cefb7612a601393cfbdf33fc56c1aa89c0976571ccc9b0
+  checksum: 10c0/02ca08dab7a8c4d44da128531a9c823dc7fbe3e31d714333b9b533108478616e2b7ee5f7c3e6520a874329e77b42edacc2043c1160c857aee4b99ab1989964dd
   languageName: node
   linkType: hard
 
@@ -780,26 +903,6 @@ __metadata:
     "@smithy/types": "npm:^4.12.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/816ae00a5feb1ff3dccc01fa9ddc3770f5a53a9a9495df5a710e6b6734f2e18c8619875ce0d213a68c67f0fe6a8fb9c099358d6e8d4b14c27bb20f0597381375
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-node@npm:^3.972.22":
-  version: 3.972.22
-  resolution: "@aws-sdk/credential-provider-node@npm:3.972.22"
-  dependencies:
-    "@aws-sdk/credential-provider-env": "npm:^3.972.19"
-    "@aws-sdk/credential-provider-http": "npm:^3.972.21"
-    "@aws-sdk/credential-provider-ini": "npm:^3.972.21"
-    "@aws-sdk/credential-provider-process": "npm:^3.972.19"
-    "@aws-sdk/credential-provider-sso": "npm:^3.972.21"
-    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.21"
-    "@aws-sdk/types": "npm:^3.973.6"
-    "@smithy/credential-provider-imds": "npm:^4.2.12"
-    "@smithy/property-provider": "npm:^4.2.12"
-    "@smithy/shared-ini-file-loader": "npm:^4.4.7"
-    "@smithy/types": "npm:^4.13.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/5ec9a3cd449834f512dc32c7c0aa8f38f4f60d0c8427097619a6403d64651b18d9a356ff7c02887553d7c602ab1e6a7c2d7bd29c49cb135c46ff3b59957aafc2
   languageName: node
   linkType: hard
 
@@ -823,17 +926,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:^3.972.19":
-  version: 3.972.19
-  resolution: "@aws-sdk/credential-provider-process@npm:3.972.19"
+"@aws-sdk/credential-provider-process@npm:^3.972.24, @aws-sdk/credential-provider-process@npm:^3.972.3":
+  version: 3.972.24
+  resolution: "@aws-sdk/credential-provider-process@npm:3.972.24"
   dependencies:
-    "@aws-sdk/core": "npm:^3.973.21"
+    "@aws-sdk/core": "npm:^3.973.26"
     "@aws-sdk/types": "npm:^3.973.6"
     "@smithy/property-provider": "npm:^4.2.12"
     "@smithy/shared-ini-file-loader": "npm:^4.4.7"
     "@smithy/types": "npm:^4.13.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/119c214a8aae2dbe0e83dcf2f8648db36dbd8ab0311f05141ae32df92ec376f2ca8a5b4bc33d26fd1235814368d3407872d73cda3caab0c2723fadccf0a28fb0
+  checksum: 10c0/4887a495b7fbd03b8b0dcd4c6105f2994b18aeafcfb8e8439fd82d38a75f8d478b2dfa54e155855434bcebdb4aa4681ddf316ef19187927cecdf01f83cab9e1f
   languageName: node
   linkType: hard
 
@@ -851,19 +954,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:^3.972.21":
-  version: 3.972.21
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.972.21"
+"@aws-sdk/credential-provider-sso@npm:^3.972.27, @aws-sdk/credential-provider-sso@npm:^3.972.3":
+  version: 3.972.27
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.972.27"
   dependencies:
-    "@aws-sdk/core": "npm:^3.973.21"
-    "@aws-sdk/nested-clients": "npm:^3.996.11"
-    "@aws-sdk/token-providers": "npm:3.1012.0"
+    "@aws-sdk/core": "npm:^3.973.26"
+    "@aws-sdk/nested-clients": "npm:^3.996.17"
+    "@aws-sdk/token-providers": "npm:3.1020.0"
     "@aws-sdk/types": "npm:^3.973.6"
     "@smithy/property-provider": "npm:^4.2.12"
     "@smithy/shared-ini-file-loader": "npm:^4.4.7"
     "@smithy/types": "npm:^4.13.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/08eb202a3602aefb4ece54c284c95867d233ce87c083cd6ab83b882ff8bf2147adb808f754055eaafe897d6e1db61fd8b5d820d1d1607b6144b8953dbbf1696e
+  checksum: 10c0/4887c6842e2f7b9a7786b1fb845989e71720efee97bffa3479b99e7a68877a12fa883a236b97371cc9c9f699ae161e5336fbdcf9aad2d533fd632922c7ed1f39
   languageName: node
   linkType: hard
 
@@ -883,18 +986,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:^3.972.21":
-  version: 3.972.21
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.21"
+"@aws-sdk/credential-provider-web-identity@npm:^3.972.27, @aws-sdk/credential-provider-web-identity@npm:^3.972.3":
+  version: 3.972.27
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.27"
   dependencies:
-    "@aws-sdk/core": "npm:^3.973.21"
-    "@aws-sdk/nested-clients": "npm:^3.996.11"
+    "@aws-sdk/core": "npm:^3.973.26"
+    "@aws-sdk/nested-clients": "npm:^3.996.17"
     "@aws-sdk/types": "npm:^3.973.6"
     "@smithy/property-provider": "npm:^4.2.12"
     "@smithy/shared-ini-file-loader": "npm:^4.4.7"
     "@smithy/types": "npm:^4.13.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/016ab1a80ef32eda9645894397b6a450685e51f7e5aff9260ebc2c56337187452a310799a3d60de90196b28951745624b3e326def833fde1f81ad0f950fa924c
+  checksum: 10c0/96d5e35ecacc7a905c46aaebd1fc01dc79929e080fe3722ba98a0d02bfec3b43afd93e54816317fc137f9b55f43029db72e70b3fc5e5a542a194cb32f23a1197
   languageName: node
   linkType: hard
 
@@ -913,31 +1016,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-providers@npm:^3.981.0":
-  version: 3.990.0
-  resolution: "@aws-sdk/credential-providers@npm:3.990.0"
+"@aws-sdk/credential-providers@npm:3.981.0":
+  version: 3.981.0
+  resolution: "@aws-sdk/credential-providers@npm:3.981.0"
   dependencies:
-    "@aws-sdk/client-cognito-identity": "npm:3.990.0"
-    "@aws-sdk/core": "npm:^3.973.10"
+    "@aws-sdk/client-cognito-identity": "npm:3.981.0"
+    "@aws-sdk/core": "npm:^3.973.5"
     "@aws-sdk/credential-provider-cognito-identity": "npm:^3.972.3"
-    "@aws-sdk/credential-provider-env": "npm:^3.972.8"
-    "@aws-sdk/credential-provider-http": "npm:^3.972.10"
-    "@aws-sdk/credential-provider-ini": "npm:^3.972.8"
-    "@aws-sdk/credential-provider-login": "npm:^3.972.8"
-    "@aws-sdk/credential-provider-node": "npm:^3.972.9"
-    "@aws-sdk/credential-provider-process": "npm:^3.972.8"
-    "@aws-sdk/credential-provider-sso": "npm:^3.972.8"
-    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.8"
-    "@aws-sdk/nested-clients": "npm:3.990.0"
+    "@aws-sdk/credential-provider-env": "npm:^3.972.3"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.5"
+    "@aws-sdk/credential-provider-ini": "npm:^3.972.3"
+    "@aws-sdk/credential-provider-login": "npm:^3.972.3"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.4"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.3"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.3"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.3"
+    "@aws-sdk/nested-clients": "npm:3.981.0"
     "@aws-sdk/types": "npm:^3.973.1"
     "@smithy/config-resolver": "npm:^4.4.6"
-    "@smithy/core": "npm:^3.23.0"
+    "@smithy/core": "npm:^3.22.0"
     "@smithy/credential-provider-imds": "npm:^4.2.8"
     "@smithy/node-config-provider": "npm:^4.3.8"
     "@smithy/property-provider": "npm:^4.2.8"
     "@smithy/types": "npm:^4.12.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/bffcb29fa4a537353d5655099c368ffcac926eb59e123be8e091f21473f778244c70d4624931b92ef36346e36e53e77dbaf24d3e764a5f2d919948e4523b8000
+  checksum: 10c0/4a82e3d70239d497bbd936195cf57d8589c52c548e98af3c300094ee1810b64a51c639ead9b4d1c530af04aa32990683a5a3142bfdb871f6b18bfd930aa0fe20
   languageName: node
   linkType: hard
 
@@ -1060,16 +1163,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-recursion-detection@npm:^3.972.8":
-  version: 3.972.8
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.972.8"
+"@aws-sdk/middleware-recursion-detection@npm:^3.972.9":
+  version: 3.972.9
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.972.9"
   dependencies:
     "@aws-sdk/types": "npm:^3.973.6"
     "@aws/lambda-invoke-store": "npm:^0.2.2"
     "@smithy/protocol-http": "npm:^5.3.12"
     "@smithy/types": "npm:^4.13.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/8d8ef442befd65dd9175294ae292e2b421171c0c9db9389a6f504b97e055dc9c3b51a80c711792fbc31cd3b4976f1d71d30a378063416553e17a59f70e7eb6d1
+  checksum: 10c0/2aadef74ed279b4d2aeb15fed943702ddce7f7cd56cb0957a288ec0450110ef11715a760391324f772d9366bb2bf7cee5d544b006da4c0344cfbc7db5feb1acc
   languageName: node
   linkType: hard
 
@@ -1121,19 +1224,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:^3.972.22":
-  version: 3.972.22
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.972.22"
+"@aws-sdk/middleware-user-agent@npm:^3.972.27":
+  version: 3.972.27
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.972.27"
   dependencies:
-    "@aws-sdk/core": "npm:^3.973.21"
+    "@aws-sdk/core": "npm:^3.973.26"
     "@aws-sdk/types": "npm:^3.973.6"
     "@aws-sdk/util-endpoints": "npm:^3.996.5"
-    "@smithy/core": "npm:^3.23.12"
+    "@smithy/core": "npm:^3.23.13"
     "@smithy/protocol-http": "npm:^5.3.12"
     "@smithy/types": "npm:^4.13.1"
     "@smithy/util-retry": "npm:^4.2.12"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/b5f95e678ab0f311ca26f5f54635b8e7e1d25f910c0592c83d15f1ca10d01df40523bc689280f81693ed17344c4738e908aeea1131d3231a65e00c699e7267d3
+  checksum: 10c0/14950d4a1841ea207199934048289bcd46a95268d8e5229d39116bf93210c7ab0daf067e3f07e1ca05114c1f481d687bb9af8cd9ed0a73e9de280ef6ade4480d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/nested-clients@npm:3.981.0":
+  version: 3.981.0
+  resolution: "@aws-sdk/nested-clients@npm:3.981.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.973.5"
+    "@aws-sdk/middleware-host-header": "npm:^3.972.3"
+    "@aws-sdk/middleware-logger": "npm:^3.972.3"
+    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.3"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.5"
+    "@aws-sdk/region-config-resolver": "npm:^3.972.3"
+    "@aws-sdk/types": "npm:^3.973.1"
+    "@aws-sdk/util-endpoints": "npm:3.981.0"
+    "@aws-sdk/util-user-agent-browser": "npm:^3.972.3"
+    "@aws-sdk/util-user-agent-node": "npm:^3.972.3"
+    "@smithy/config-resolver": "npm:^4.4.6"
+    "@smithy/core": "npm:^3.22.0"
+    "@smithy/fetch-http-handler": "npm:^5.3.9"
+    "@smithy/hash-node": "npm:^4.2.8"
+    "@smithy/invalid-dependency": "npm:^4.2.8"
+    "@smithy/middleware-content-length": "npm:^4.2.8"
+    "@smithy/middleware-endpoint": "npm:^4.4.12"
+    "@smithy/middleware-retry": "npm:^4.4.29"
+    "@smithy/middleware-serde": "npm:^4.2.9"
+    "@smithy/middleware-stack": "npm:^4.2.8"
+    "@smithy/node-config-provider": "npm:^4.3.8"
+    "@smithy/node-http-handler": "npm:^4.4.8"
+    "@smithy/protocol-http": "npm:^5.3.8"
+    "@smithy/smithy-client": "npm:^4.11.1"
+    "@smithy/types": "npm:^4.12.0"
+    "@smithy/url-parser": "npm:^4.2.8"
+    "@smithy/util-base64": "npm:^4.3.0"
+    "@smithy/util-body-length-browser": "npm:^4.2.0"
+    "@smithy/util-body-length-node": "npm:^4.2.1"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.28"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.31"
+    "@smithy/util-endpoints": "npm:^3.2.8"
+    "@smithy/util-middleware": "npm:^4.2.8"
+    "@smithy/util-retry": "npm:^4.2.8"
+    "@smithy/util-utf8": "npm:^4.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/31a13021385af52c05a6ad08e2168bf3fd1076d8f42fea659a1a9fe80a764f12dbd3d455198d2b4f7f6507960d3ea832163180328ba96f0f88f3f8d5d437d343
   languageName: node
   linkType: hard
 
@@ -1183,49 +1332,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/nested-clients@npm:^3.996.11":
-  version: 3.996.11
-  resolution: "@aws-sdk/nested-clients@npm:3.996.11"
+"@aws-sdk/nested-clients@npm:^3.996.17":
+  version: 3.996.17
+  resolution: "@aws-sdk/nested-clients@npm:3.996.17"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:^3.973.21"
+    "@aws-sdk/core": "npm:^3.973.26"
     "@aws-sdk/middleware-host-header": "npm:^3.972.8"
     "@aws-sdk/middleware-logger": "npm:^3.972.8"
-    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.8"
-    "@aws-sdk/middleware-user-agent": "npm:^3.972.22"
-    "@aws-sdk/region-config-resolver": "npm:^3.972.8"
+    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.9"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.27"
+    "@aws-sdk/region-config-resolver": "npm:^3.972.10"
     "@aws-sdk/types": "npm:^3.973.6"
     "@aws-sdk/util-endpoints": "npm:^3.996.5"
     "@aws-sdk/util-user-agent-browser": "npm:^3.972.8"
-    "@aws-sdk/util-user-agent-node": "npm:^3.973.8"
-    "@smithy/config-resolver": "npm:^4.4.11"
-    "@smithy/core": "npm:^3.23.12"
+    "@aws-sdk/util-user-agent-node": "npm:^3.973.13"
+    "@smithy/config-resolver": "npm:^4.4.13"
+    "@smithy/core": "npm:^3.23.13"
     "@smithy/fetch-http-handler": "npm:^5.3.15"
     "@smithy/hash-node": "npm:^4.2.12"
     "@smithy/invalid-dependency": "npm:^4.2.12"
     "@smithy/middleware-content-length": "npm:^4.2.12"
-    "@smithy/middleware-endpoint": "npm:^4.4.26"
-    "@smithy/middleware-retry": "npm:^4.4.43"
-    "@smithy/middleware-serde": "npm:^4.2.15"
+    "@smithy/middleware-endpoint": "npm:^4.4.28"
+    "@smithy/middleware-retry": "npm:^4.4.45"
+    "@smithy/middleware-serde": "npm:^4.2.16"
     "@smithy/middleware-stack": "npm:^4.2.12"
     "@smithy/node-config-provider": "npm:^4.3.12"
-    "@smithy/node-http-handler": "npm:^4.5.0"
+    "@smithy/node-http-handler": "npm:^4.5.1"
     "@smithy/protocol-http": "npm:^5.3.12"
-    "@smithy/smithy-client": "npm:^4.12.6"
+    "@smithy/smithy-client": "npm:^4.12.8"
     "@smithy/types": "npm:^4.13.1"
     "@smithy/url-parser": "npm:^4.2.12"
     "@smithy/util-base64": "npm:^4.3.2"
     "@smithy/util-body-length-browser": "npm:^4.2.2"
     "@smithy/util-body-length-node": "npm:^4.2.3"
-    "@smithy/util-defaults-mode-browser": "npm:^4.3.42"
-    "@smithy/util-defaults-mode-node": "npm:^4.2.45"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.44"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.48"
     "@smithy/util-endpoints": "npm:^3.3.3"
     "@smithy/util-middleware": "npm:^4.2.12"
     "@smithy/util-retry": "npm:^4.2.12"
     "@smithy/util-utf8": "npm:^4.2.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/265ae0630214bb76e55fad4a3a7df1ce84a7542205c28ad132c56f2e7ab00d490e1548af19f3042e07044d961c6116a4e3a2e68cb3ec1218647947645c96e06a
+  checksum: 10c0/fe8b11b3a4a9bc932f70387dcfea1325989a23157e6a6373f46896087c7ce14b33af17d7ebce1c5528eb912c2fcac4b9713e60fd59ee9ce1831cff23ec2c66d5
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/region-config-resolver@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/region-config-resolver@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.6"
+    "@smithy/config-resolver": "npm:^4.4.13"
+    "@smithy/node-config-provider": "npm:^4.3.12"
+    "@smithy/types": "npm:^4.13.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b385fa5be853c7bd5110c80eafd400890affe7c753c0fd1ebbc213d4943aa9cfac2b609ea36b1ac68f542c05b73586f314718c33180ffc75d4ca9bf7bb564d95
   languageName: node
   linkType: hard
 
@@ -1239,19 +1401,6 @@ __metadata:
     "@smithy/types": "npm:^4.12.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/6682f729ba131b9067f7af77bcb49f3cae41668614e5c3b21ce8f091346a6961e852d0b72e15f262ad1fdccc9f4190680b35f756244cd691b6314b2866e071d9
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/region-config-resolver@npm:^3.972.8":
-  version: 3.972.8
-  resolution: "@aws-sdk/region-config-resolver@npm:3.972.8"
-  dependencies:
-    "@aws-sdk/types": "npm:^3.973.6"
-    "@smithy/config-resolver": "npm:^4.4.11"
-    "@smithy/node-config-provider": "npm:^4.3.12"
-    "@smithy/types": "npm:^4.13.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/9532a6516053a15d317c4b114492fb47c9411a4a7bded7161738c59c85df19a4b14120e376573c48b23d7a6c84c5a9e29b4f6f8e9cf0d22882e12b27001704a5
   languageName: node
   linkType: hard
 
@@ -1285,18 +1434,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.1012.0":
-  version: 3.1012.0
-  resolution: "@aws-sdk/token-providers@npm:3.1012.0"
+"@aws-sdk/token-providers@npm:3.1020.0":
+  version: 3.1020.0
+  resolution: "@aws-sdk/token-providers@npm:3.1020.0"
   dependencies:
-    "@aws-sdk/core": "npm:^3.973.21"
-    "@aws-sdk/nested-clients": "npm:^3.996.11"
+    "@aws-sdk/core": "npm:^3.973.26"
+    "@aws-sdk/nested-clients": "npm:^3.996.17"
     "@aws-sdk/types": "npm:^3.973.6"
     "@smithy/property-provider": "npm:^4.2.12"
     "@smithy/shared-ini-file-loader": "npm:^4.4.7"
     "@smithy/types": "npm:^4.13.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/8919516f3e6d87094afb254b32fcce4912f6f5ccbf915d7ce837a176120c1ea0ade82aa5393136d8691b35dfe9ab45ae366a94b5c23e7b6ea9a97fcdbf7cbfc3
+  checksum: 10c0/be38a254f67a0b5bba5386d8ced3ad2a67b89ef893009cf5ebbb8ae2efe766ec03d93eac29acad65e53e675217e585be3548ca058555013fc5ef40e61ea3bd5c
   languageName: node
   linkType: hard
 
@@ -1364,6 +1513,19 @@ __metadata:
     "@smithy/util-endpoints": "npm:^3.2.8"
     tslib: "npm:^2.6.2"
   checksum: 10c0/0de91a4d1e2382f45fbfcbd4e1424d2088fd58479483235b5dec23875a10fe11502a2482295ef14763793eeb607c4a0c1f75d2fc4101868e33f0837deab9a6ba
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-endpoints@npm:3.981.0":
+  version: 3.981.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.981.0"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.1"
+    "@smithy/types": "npm:^4.12.0"
+    "@smithy/url-parser": "npm:^4.2.8"
+    "@smithy/util-endpoints": "npm:^3.2.8"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/d5256572280189e00ea7257f952a1c3fcc23e2245d65abda80c6734fe8dc7874658d74a09bf3284c5119a7fc5dfa5b2c4d711c5a812fdf0519ae0fa9997b5f68
   languageName: node
   linkType: hard
 
@@ -1456,11 +1618,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:^3.973.8":
-  version: 3.973.8
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.973.8"
+"@aws-sdk/util-user-agent-node@npm:^3.973.13":
+  version: 3.973.13
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.973.13"
   dependencies:
-    "@aws-sdk/middleware-user-agent": "npm:^3.972.22"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.27"
     "@aws-sdk/types": "npm:^3.973.6"
     "@smithy/node-config-provider": "npm:^4.3.12"
     "@smithy/types": "npm:^4.13.1"
@@ -1471,7 +1633,7 @@ __metadata:
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: 10c0/8c37ce6ce3bdad8447ddb5645e1cf216315e88ac6edc9ffaac65af475cc4f0d83d44223f7755fd5ab894636405ad5a34d6e2d6ab491eb8bb0453f252f454dbc1
+  checksum: 10c0/742ab3200941b48898adc1134c0e43bb122056fb0f2ca4a2ffc47c76297085a42adb78109f3ce14aa676745b8f8dc89909e870a3d282fa27f10de83f6f8134ed
   languageName: node
   linkType: hard
 
@@ -1483,6 +1645,17 @@ __metadata:
     fast-xml-parser: "npm:5.5.6"
     tslib: "npm:^2.6.2"
   checksum: 10c0/c7ecc550f6305d609b46a31eefb38c94e89f2b0edb9576a7951c05f3a43333cd469543a4c80d6ab9451738542fe425de016038ce7345f8914a6b3d3bc2eff5c9
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:^3.972.16":
+  version: 3.972.16
+  resolution: "@aws-sdk/xml-builder@npm:3.972.16"
+  dependencies:
+    "@smithy/types": "npm:^4.13.1"
+    fast-xml-parser: "npm:5.5.8"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4a0c5dd7dca0eae3d33d18b1dd94921a2ae06937f92503918ed3c22182a728b7317836ca3a91ca2d26b371eb33b37f23e4b566a1db46f204f6fd31fd323e7464
   languageName: node
   linkType: hard
 
@@ -1536,49 +1709,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/datadog-ci-base@npm:^5.9.1":
-  version: 5.9.1
-  resolution: "@datadog/datadog-ci-base@npm:5.9.1"
+"@datadog/datadog-ci-base@npm:5.11.0":
+  version: 5.11.0
+  resolution: "@datadog/datadog-ci-base@npm:5.11.0"
   dependencies:
-    "@antfu/install-pkg": "npm:^1.1.0"
+    "@antfu/install-pkg": "npm:1.1.0"
     "@types/datadog-metrics": "npm:0.6.1"
     async-retry: "npm:1.3.1"
-    axios: "npm:^1.13.5"
+    axios: "npm:1.13.5"
     chalk: "npm:3.0.0"
-    clipanion: "npm:^3.2.1"
+    clipanion: "npm:3.2.1"
     datadog-metrics: "npm:0.9.3"
-    debug: "npm:^4.4.1"
+    debug: "npm:4.4.1"
     deep-extend: "npm:0.6.0"
-    fast-xml-parser: "npm:^5.3.7"
-    form-data: "npm:^4.0.4"
-    glob: "npm:^13.0.5"
-    inquirer: "npm:^8.2.6"
-    is-docker: "npm:^4.0.0"
-    jest-diff: "npm:^30.2.0"
+    fast-xml-parser: "npm:5.3.7"
+    form-data: "npm:4.0.4"
+    glob: "npm:13.0.5"
+    inquirer: "npm:8.2.7"
+    is-docker: "npm:4.0.0"
+    jest-diff: "npm:30.2.0"
     js-yaml: "npm:4.1.1"
-    jszip: "npm:^3.10.1"
-    proxy-agent: "npm:^6.4.0"
-    semver: "npm:^7.5.3"
+    jszip: "npm:3.10.1"
+    proxy-agent: "npm:6.4.0"
+    semver: "npm:7.6.3"
     simple-git: "npm:3.33.0"
     terminal-link: "npm:2.1.1"
-    tiny-async-pool: "npm:^2.1.0"
-    typanion: "npm:^3.14.0"
-    upath: "npm:^2.0.1"
+    tiny-async-pool: "npm:2.1.0"
+    typanion: "npm:3.14.0"
+    upath: "npm:2.0.1"
   peerDependencies:
-    "@datadog/datadog-ci-plugin-aas": 5.9.1
-    "@datadog/datadog-ci-plugin-cloud-run": 5.9.1
-    "@datadog/datadog-ci-plugin-container-app": 5.9.1
-    "@datadog/datadog-ci-plugin-coverage": 5.9.1
-    "@datadog/datadog-ci-plugin-deployment": 5.9.1
-    "@datadog/datadog-ci-plugin-dora": 5.9.1
-    "@datadog/datadog-ci-plugin-gate": 5.9.1
-    "@datadog/datadog-ci-plugin-junit": 5.9.1
-    "@datadog/datadog-ci-plugin-lambda": 5.9.1
-    "@datadog/datadog-ci-plugin-sarif": 5.9.1
-    "@datadog/datadog-ci-plugin-sbom": 5.9.1
-    "@datadog/datadog-ci-plugin-stepfunctions": 5.9.1
-    "@datadog/datadog-ci-plugin-synthetics": 5.9.1
-    "@datadog/datadog-ci-plugin-terraform": 5.9.1
+    "@datadog/datadog-ci-plugin-aas": 5.11.0
+    "@datadog/datadog-ci-plugin-cloud-run": 5.11.0
+    "@datadog/datadog-ci-plugin-container-app": 5.11.0
+    "@datadog/datadog-ci-plugin-coverage": 5.11.0
+    "@datadog/datadog-ci-plugin-deployment": 5.11.0
+    "@datadog/datadog-ci-plugin-dora": 5.11.0
+    "@datadog/datadog-ci-plugin-gate": 5.11.0
+    "@datadog/datadog-ci-plugin-junit": 5.11.0
+    "@datadog/datadog-ci-plugin-lambda": 5.11.0
+    "@datadog/datadog-ci-plugin-sarif": 5.11.0
+    "@datadog/datadog-ci-plugin-sbom": 5.11.0
+    "@datadog/datadog-ci-plugin-stepfunctions": 5.11.0
+    "@datadog/datadog-ci-plugin-synthetics": 5.11.0
+    "@datadog/datadog-ci-plugin-terraform": 5.11.0
   peerDependenciesMeta:
     "@datadog/datadog-ci-plugin-aas":
       optional: true
@@ -1608,32 +1781,29 @@ __metadata:
       optional: true
     "@datadog/datadog-ci-plugin-terraform":
       optional: true
-  checksum: 10c0/46d4ca951f5b442c0d2c5038703f25c646f700ed48c5b4e23caa33dc091eab5fcec865b4380c1348d0ba2314fea8e1588051248ceba99ca1514a8195b05fc2b4
+  checksum: 10c0/ad7d4476a478b2c97b2e63e2bb25fb2c8ad7dc7a85761e2d7d543fc488d6826e03e34ed3881e7c2a9e06f20d2bbcbca9a636bf82e62826973b49f3e56aa58cb6
   languageName: node
   linkType: hard
 
-"@datadog/datadog-ci-plugin-lambda@npm:^5.9.1":
-  version: 5.9.1
-  resolution: "@datadog/datadog-ci-plugin-lambda@npm:5.9.1"
+"@datadog/datadog-ci-plugin-lambda@npm:5.11.0":
+  version: 5.11.0
+  resolution: "@datadog/datadog-ci-plugin-lambda@npm:5.11.0"
   dependencies:
-    "@aws-sdk/client-cloudwatch-logs": "npm:^3.981.0"
-    "@aws-sdk/client-iam": "npm:^3.981.0"
-    "@aws-sdk/client-lambda": "npm:^3.981.0"
-    "@aws-sdk/credential-provider-ini": "npm:^3.972.9"
-    "@aws-sdk/credential-providers": "npm:^3.981.0"
-    "@aws-sdk/types": "npm:^3.973.1"
-    "@smithy/property-provider": "npm:^2.0.12"
-    "@smithy/util-retry": "npm:^2.0.4"
+    "@aws-sdk/client-cloudwatch-logs": "npm:3.981.0"
+    "@aws-sdk/client-iam": "npm:3.981.0"
+    "@aws-sdk/client-lambda": "npm:3.981.0"
+    "@aws-sdk/credential-providers": "npm:3.981.0"
+    "@smithy/property-provider": "npm:2.2.0"
+    "@smithy/util-retry": "npm:2.2.0"
     chalk: "npm:3.0.0"
-    fuzzy: "npm:^0.1.3"
-    inquirer: "npm:^8.2.6"
-    inquirer-checkbox-plus-prompt: "npm:^1.4.2"
+    fuzzy: "npm:0.1.3"
+    inquirer: "npm:8.2.7"
+    inquirer-checkbox-plus-prompt: "npm:1.4.2"
     ora: "npm:5.4.1"
-    typanion: "npm:^3.14.0"
-    upath: "npm:^2.0.1"
+    upath: "npm:2.0.1"
   peerDependencies:
-    "@datadog/datadog-ci-base": 5.9.1
-  checksum: 10c0/1cc1ba96ffbf3b70e224801784a5394b5196c04a9d7c92cadf52181691a4e66237003c123a96818bb7c7cd1a45254a57e6338347a1a3f238e94d23f0df54015d
+    "@datadog/datadog-ci-base": 5.11.0
+  checksum: 10c0/2e92894ed472fede505d302b41ea93439fea6dcd85b2bc08253947dd29ef446a9b3ab7775275b766de5c7d8f7327bb186f06a7dea19b004650a537546f4e9d7b
   languageName: node
   linkType: hard
 
@@ -2396,9 +2566,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/config-resolver@npm:^4.4.11, @smithy/config-resolver@npm:^4.4.12":
-  version: 4.4.12
-  resolution: "@smithy/config-resolver@npm:4.4.12"
+"@smithy/config-resolver@npm:^4.4.13":
+  version: 4.4.13
+  resolution: "@smithy/config-resolver@npm:4.4.13"
   dependencies:
     "@smithy/node-config-provider": "npm:^4.3.12"
     "@smithy/types": "npm:^4.13.1"
@@ -2406,7 +2576,7 @@ __metadata:
     "@smithy/util-endpoints": "npm:^3.3.3"
     "@smithy/util-middleware": "npm:^4.2.12"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/a44435acb58334dd6c1feef2fc55ab27db71eb071a6f542b130a5a0581dd645f88364bea4219ae88cffba72053305240ded7ba055dd55f17fde3ba3777541de9
+  checksum: 10c0/4087584b0c5a5207a847b951072eedbf485c0e908ec750270c5f0fe7a15dd9e22857ced0fc24a6fdfde4d4937219b5f4f12c63cbc0f6371d161512b00af293cb
   languageName: node
   linkType: hard
 
@@ -2457,6 +2627,24 @@ __metadata:
     "@smithy/uuid": "npm:^1.1.2"
     tslib: "npm:^2.6.2"
   checksum: 10c0/48add70de8829d8fa4dd62e808e5850dd60e7dcd4f08f2720f573479de1f88a688b1268dc6158476549a9d3e1510df445d3f4b8768f5b2d32fc2fbe3ee3feb65
+  languageName: node
+  linkType: hard
+
+"@smithy/core@npm:^3.23.13":
+  version: 3.23.13
+  resolution: "@smithy/core@npm:3.23.13"
+  dependencies:
+    "@smithy/protocol-http": "npm:^5.3.12"
+    "@smithy/types": "npm:^4.13.1"
+    "@smithy/url-parser": "npm:^4.2.12"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-body-length-browser": "npm:^4.2.2"
+    "@smithy/util-middleware": "npm:^4.2.12"
+    "@smithy/util-stream": "npm:^4.5.21"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    "@smithy/uuid": "npm:^1.1.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/c264c0a097cfe237b7a089ac245bbb323ed06cf019dd94c0722422ea7a771fe3617c7b4c0b4b04bb88386e4d7df5e8c0720caef8422fe8b7ff64c8d132c2d38b
   languageName: node
   linkType: hard
 
@@ -2726,6 +2914,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-endpoint@npm:^4.4.28":
+  version: 4.4.28
+  resolution: "@smithy/middleware-endpoint@npm:4.4.28"
+  dependencies:
+    "@smithy/core": "npm:^3.23.13"
+    "@smithy/middleware-serde": "npm:^4.2.16"
+    "@smithy/node-config-provider": "npm:^4.3.12"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.7"
+    "@smithy/types": "npm:^4.13.1"
+    "@smithy/url-parser": "npm:^4.2.12"
+    "@smithy/util-middleware": "npm:^4.2.12"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4862f02ef3d6a0c5738957cadda976ac503849fa339aaee703e9e2023822a084a4440254570e037f61f5ccd4c892cdcbe54f0ce4a99879f3aab7cfb0b9bdf11d
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-retry@npm:^4.4.29, @smithy/middleware-retry@npm:^4.4.31":
   version: 4.4.31
   resolution: "@smithy/middleware-retry@npm:4.4.31"
@@ -2743,20 +2947,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-retry@npm:^4.4.43":
-  version: 4.4.43
-  resolution: "@smithy/middleware-retry@npm:4.4.43"
+"@smithy/middleware-retry@npm:^4.4.45":
+  version: 4.4.46
+  resolution: "@smithy/middleware-retry@npm:4.4.46"
   dependencies:
     "@smithy/node-config-provider": "npm:^4.3.12"
     "@smithy/protocol-http": "npm:^5.3.12"
     "@smithy/service-error-classification": "npm:^4.2.12"
-    "@smithy/smithy-client": "npm:^4.12.6"
+    "@smithy/smithy-client": "npm:^4.12.8"
     "@smithy/types": "npm:^4.13.1"
     "@smithy/util-middleware": "npm:^4.2.12"
-    "@smithy/util-retry": "npm:^4.2.12"
+    "@smithy/util-retry": "npm:^4.2.13"
     "@smithy/uuid": "npm:^1.1.2"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/c34ae57a2d536b0be40235553e46ee3278538a3debee44264da09c0d02883445f6e3607851956b41f31a5bf74904d66740171bbe09c3409695171de1b39fa99e
+  checksum: 10c0/ed2e0d2b996cc26bd874fbe43a44cb699a762f9e0ab064599e6c0e9d99952b2102bb573beb5cb8439e15df23178db3344460f5d1859e10b803c33c05174f10e8
   languageName: node
   linkType: hard
 
@@ -2769,6 +2973,18 @@ __metadata:
     "@smithy/types": "npm:^4.13.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/651c775eafba0cea9fe67e9d24afc73d31d371949b9bdfb109aa242f9899fb8334504e37b00a6b51e6f9f522daa68c89fb7cc451e50faa4cf8990d23a2470c67
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-serde@npm:^4.2.16":
+  version: 4.2.16
+  resolution: "@smithy/middleware-serde@npm:4.2.16"
+  dependencies:
+    "@smithy/core": "npm:^3.23.13"
+    "@smithy/protocol-http": "npm:^5.3.12"
+    "@smithy/types": "npm:^4.13.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/8b375acd4d54178c8195180c52fb757c85339feadc9de3b2bbf1e0bb12ca193f614f4d69b20f529496fa4c469e1b7e19762e0d98c345aa50530d6e6af2a04ec9
   languageName: node
   linkType: hard
 
@@ -2866,7 +3082,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/property-provider@npm:^2.0.12":
+"@smithy/node-http-handler@npm:^4.5.1":
+  version: 4.5.1
+  resolution: "@smithy/node-http-handler@npm:4.5.1"
+  dependencies:
+    "@smithy/protocol-http": "npm:^5.3.12"
+    "@smithy/querystring-builder": "npm:^4.2.12"
+    "@smithy/types": "npm:^4.13.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e0564c285be81c9dbbc53bf6c6c36568b0b0760c63bc6d28eeae1f5cde43925b52e739a45d9cfeae7c6014a8b31eb52ba931aea96a5b428735a5ea0641054b69
+  languageName: node
+  linkType: hard
+
+"@smithy/property-provider@npm:2.2.0":
   version: 2.2.0
   resolution: "@smithy/property-provider@npm:2.2.0"
   dependencies:
@@ -3067,6 +3295,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/smithy-client@npm:^4.12.8":
+  version: 4.12.8
+  resolution: "@smithy/smithy-client@npm:4.12.8"
+  dependencies:
+    "@smithy/core": "npm:^3.23.13"
+    "@smithy/middleware-endpoint": "npm:^4.4.28"
+    "@smithy/middleware-stack": "npm:^4.2.12"
+    "@smithy/protocol-http": "npm:^5.3.12"
+    "@smithy/types": "npm:^4.13.1"
+    "@smithy/util-stream": "npm:^4.5.21"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/5bb76a4465490c08e745d952b7c43bbddc57e3dc848a0ffd494d466917215f8878ae27139a1dca212c7edb05622fb289628fb116a196c8319bd490edb95be929
+  languageName: node
+  linkType: hard
+
 "@smithy/types@npm:^2.12.0":
   version: 2.12.0
   resolution: "@smithy/types@npm:2.12.0"
@@ -3243,15 +3486,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-browser@npm:^4.3.42":
-  version: 4.3.42
-  resolution: "@smithy/util-defaults-mode-browser@npm:4.3.42"
+"@smithy/util-defaults-mode-browser@npm:^4.3.44":
+  version: 4.3.44
+  resolution: "@smithy/util-defaults-mode-browser@npm:4.3.44"
   dependencies:
     "@smithy/property-provider": "npm:^4.2.12"
-    "@smithy/smithy-client": "npm:^4.12.6"
+    "@smithy/smithy-client": "npm:^4.12.8"
     "@smithy/types": "npm:^4.13.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/1fcff58153a5622764a79e1969d93eee15b9b8a224c6bc96b0a7ab6410a749d1ba8e33c5c563cc60b3676c70f7f30fafd27ab7da9446cf021aef04f5ee724123
+  checksum: 10c0/6465df7408f978c3c73a530c5ca840d663e134be76396a81af6fcbeba8d7eb66cbb0001d349dae514dbf0f88d9a56c2cc900e78d1f0fc5b33ec7aba255632474
   languageName: node
   linkType: hard
 
@@ -3270,18 +3513,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-node@npm:^4.2.45":
-  version: 4.2.46
-  resolution: "@smithy/util-defaults-mode-node@npm:4.2.46"
+"@smithy/util-defaults-mode-node@npm:^4.2.48":
+  version: 4.2.48
+  resolution: "@smithy/util-defaults-mode-node@npm:4.2.48"
   dependencies:
-    "@smithy/config-resolver": "npm:^4.4.12"
+    "@smithy/config-resolver": "npm:^4.4.13"
     "@smithy/credential-provider-imds": "npm:^4.2.12"
     "@smithy/node-config-provider": "npm:^4.3.12"
     "@smithy/property-provider": "npm:^4.2.12"
-    "@smithy/smithy-client": "npm:^4.12.6"
+    "@smithy/smithy-client": "npm:^4.12.8"
     "@smithy/types": "npm:^4.13.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/aff5242c27062b1dd760d63c13a16e2047ec80219155a77c46bd02478295988f19e97677e90baea6e9d5c9d3e6f3e7d025b134c09c38745b8cfc7d3f2c37bf5d
+  checksum: 10c0/e54f8d502eaa7fff9a5e6f53ca27573bfeaac0c659dc12f52ca8a53244ae2cfbc6865422773c1d09934d1dbc4050bc876d0ae0709d8b5db9170685611dca2474
   languageName: node
   linkType: hard
 
@@ -3345,7 +3588,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-retry@npm:^2.0.4":
+"@smithy/util-retry@npm:2.2.0":
   version: 2.2.0
   resolution: "@smithy/util-retry@npm:2.2.0"
   dependencies:
@@ -3367,6 +3610,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-retry@npm:^4.2.13":
+  version: 4.2.13
+  resolution: "@smithy/util-retry@npm:4.2.13"
+  dependencies:
+    "@smithy/service-error-classification": "npm:^4.2.12"
+    "@smithy/types": "npm:^4.13.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/14c1a24d8db429ceb7364d2b13bb3294d891d90e34fb5a9fd4e59b0c2862c56854dd242303a3210cdfedbd086660ab3d2b0cf992ee012a30f1539aba7b35dae3
+  languageName: node
+  linkType: hard
+
 "@smithy/util-retry@npm:^4.2.8":
   version: 4.2.8
   resolution: "@smithy/util-retry@npm:4.2.8"
@@ -3375,6 +3629,22 @@ __metadata:
     "@smithy/types": "npm:^4.12.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/5329f7e0144114ce7bece310a30c0f094adfe3bcb4a3c9d6d67bb0a8fef72b454bad4ccfecb8cfbeaae025c10a668e88beca08a7e04f28ec8faad8f16db791e9
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^4.5.10, @smithy/util-stream@npm:^4.5.21":
+  version: 4.5.21
+  resolution: "@smithy/util-stream@npm:4.5.21"
+  dependencies:
+    "@smithy/fetch-http-handler": "npm:^5.3.15"
+    "@smithy/node-http-handler": "npm:^4.5.1"
+    "@smithy/types": "npm:^4.13.1"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-buffer-from": "npm:^4.2.2"
+    "@smithy/util-hex-encoding": "npm:^4.2.2"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/dc9b81e1f17c234f74a699e4d003cf99e07545c83f1d289cb8e64bcbfd180b64bce79b3c83a1c2eddc719b4e6224c4dc96d237641bab89a8b2ce1b26bacad6c7
   languageName: node
   linkType: hard
 
@@ -3455,17 +3725,6 @@ __metadata:
     "@smithy/util-buffer-from": "npm:^4.2.2"
     tslib: "npm:^2.6.2"
   checksum: 10c0/55b5119873237519a9175491c74fd0a14acd4f9c54c7eec9ae547de6c554098912d46572edb12d5b52a0b9675c0577e2e63d1f7cb8e022ca342f5bf80b56a466
-  languageName: node
-  linkType: hard
-
-"@smithy/util-waiter@npm:^4.2.13":
-  version: 4.2.13
-  resolution: "@smithy/util-waiter@npm:4.2.13"
-  dependencies:
-    "@smithy/abort-controller": "npm:^4.2.12"
-    "@smithy/types": "npm:^4.13.1"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/02e29879d64214f01e0acf7f9e1157e5aa671371f9e2fb46fc75595e330f785e237c60eba44eb039c8598bfc0fdf3bcb6556742f6631605f71e856f9267524e9
   languageName: node
   linkType: hard
 
@@ -3982,7 +4241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
+"agent-base@npm:^7.0.2, agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
   version: 7.1.4
   resolution: "agent-base@npm:7.1.4"
   checksum: 10c0/c2c9ab7599692d594b6a161559ada307b7a624fa4c7b03e3afdb5a5e31cd0e53269115b620fcab024c5ac6a6f37fa5eb2e004f076ad30f5f7e6b8b671f7b35fe
@@ -4179,14 +4438,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.13.5, axios@npm:^1.13.6":
-  version: 1.13.6
-  resolution: "axios@npm:1.13.6"
+"axios@npm:1.13.5":
+  version: 1.13.5
+  resolution: "axios@npm:1.13.5"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/51fb5af055c3b85662fa97df17d986ae2c37d13bf86d50b6bb36b6b3a2dec6966a1d3a14ab3774b71707b155ae3597ed9b7babdf1a1a863d1a31840cb8e7ec71
+  checksum: 10c0/abf468c34f2d145f3dc7dbc0f1be67e520630624307bda69a41bbe8d386bd672d87b4405c4ee77f9ff54b235ab02f96a9968fb00e75b13ce64706e352a3068fd
   languageName: node
   linkType: hard
 
@@ -4270,6 +4529,15 @@ __metadata:
   dependencies:
     balanced-match: "npm:^4.0.2"
   checksum: 10c0/60c765e5df6fc0ceca3d5703202ae6779db61f28ea3bf93a04dbf0d50c22ef8e4644e09d0459c827077cd2d09ba8f199a04d92c36419fcf874601a5565013174
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "brace-expansion@npm:5.0.5"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
   languageName: node
   linkType: hard
 
@@ -4426,7 +4694,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clipanion@npm:^3.2.1":
+"clipanion@npm:3.2.1":
   version: 3.2.1
   resolution: "clipanion@npm:3.2.1"
   dependencies:
@@ -4557,7 +4825,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -4566,6 +4834,18 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
+  languageName: node
+  linkType: hard
+
+"debug@npm:4.4.1":
+  version: 4.4.1
+  resolution: "debug@npm:4.4.1"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/d2b44bc1afd912b49bb7ebb0d50a860dc93a4dd7d946e8de94abc957bb63726b7dd5aa48c18c2386c379ec024c46692e15ed3ed97d481729f929201e671fcd55
   languageName: node
   linkType: hard
 
@@ -5240,6 +5520,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-xml-parser@npm:5.3.7":
+  version: 5.3.7
+  resolution: "fast-xml-parser@npm:5.3.7"
+  dependencies:
+    strnum: "npm:^2.1.2"
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: 10c0/2452b8d4557f6958507ccb9694dad094fb56342385774ee900e0ae1e193027a6590dd5c4ce9e5485af64fb18c2299b64d5423c82dba5f5a698950d36d02a864d
+  languageName: node
+  linkType: hard
+
 "fast-xml-parser@npm:5.5.6":
   version: 5.5.6
   resolution: "fast-xml-parser@npm:5.5.6"
@@ -5253,16 +5544,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^5.3.7":
-  version: 5.5.7
-  resolution: "fast-xml-parser@npm:5.5.7"
+"fast-xml-parser@npm:5.5.8":
+  version: 5.5.8
+  resolution: "fast-xml-parser@npm:5.5.8"
   dependencies:
     fast-xml-builder: "npm:^1.1.4"
-    path-expression-matcher: "npm:^1.1.3"
+    path-expression-matcher: "npm:^1.2.0"
     strnum: "npm:^2.2.0"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/aa8a8555b62c44c9fd3a48febd1a58e058727525c1cc14c1992a2d48c76b80e8c60e1baa9c639ded760a1c4dd951912342ce820fd59edbc88b7864a9ba25c0fe
+  checksum: 10c0/b0eb5b5b4b02bb2dfac2fac4c19ce834017553e1f74499929a196b67bfe0741389a89dca4662c97bff138646d7c5fd985af59c7a216c433717e854de3355638c
   languageName: node
   linkType: hard
 
@@ -5371,7 +5662,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.4":
+"form-data@npm:4.0.4, form-data@npm:^4.0.4":
   version: 4.0.4
   resolution: "form-data@npm:4.0.4"
   dependencies:
@@ -5450,7 +5741,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fuzzy@npm:^0.1.3":
+"fuzzy@npm:0.1.3":
   version: 0.1.3
   resolution: "fuzzy@npm:0.1.3"
   checksum: 10c0/584fcd57a03431707a6d0c1c4a41f17368cdb23d37dcb176d6cbbeeaecaac51be15dec229b3547acfb7db052cb066fcd86db907d40112ac4a3d3a368f88e7105
@@ -5524,6 +5815,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:13.0.5":
+  version: 13.0.5
+  resolution: "glob@npm:13.0.5"
+  dependencies:
+    minimatch: "npm:^10.2.1"
+    minipass: "npm:^7.1.2"
+    path-scurry: "npm:^2.0.0"
+  checksum: 10c0/1388527676127f337877eaf3403d6c54d3fa5e5599e10c1532d73108435b4da66d8fff4b00eb5b306388090a180c6a92d70694df1c19171cf820e285fb1dfee5
+  languageName: node
+  linkType: hard
+
 "glob@npm:^13.0.0":
   version: 13.0.3
   resolution: "glob@npm:13.0.3"
@@ -5532,17 +5834,6 @@ __metadata:
     minipass: "npm:^7.1.2"
     path-scurry: "npm:^2.0.0"
   checksum: 10c0/333dc5c40ca0e50400465d8f5c45aa7cdd32580c4d1a4c502dfb4fb9c469a936b8e0c6bbd09cd6353fd05982e48d7f79e819159a36fb3e0a41ee722607bc11a9
-  languageName: node
-  linkType: hard
-
-"glob@npm:^13.0.5":
-  version: 13.0.6
-  resolution: "glob@npm:13.0.6"
-  dependencies:
-    minimatch: "npm:^10.2.2"
-    minipass: "npm:^7.1.3"
-    path-scurry: "npm:^2.0.2"
-  checksum: 10c0/269c236f11a9b50357fe7a8c6aadac667e01deb5242b19c84975628f05f4438d8ee1354bb62c5d6c10f37fd59911b54d7799730633a2786660d8c69f1d18120a
   languageName: node
   linkType: hard
 
@@ -5676,7 +5967,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.6":
+"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.3, https-proxy-agent@npm:^7.0.6":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
@@ -5780,7 +6071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inquirer-checkbox-plus-prompt@npm:^1.4.2":
+"inquirer-checkbox-plus-prompt@npm:1.4.2":
   version: 1.4.2
   resolution: "inquirer-checkbox-plus-prompt@npm:1.4.2"
   dependencies:
@@ -5795,7 +6086,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inquirer@npm:^8.2.6":
+"inquirer@npm:8.2.7":
   version: 8.2.7
   resolution: "inquirer@npm:8.2.7"
   dependencies:
@@ -5825,7 +6116,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-docker@npm:^4.0.0":
+"is-docker@npm:4.0.0":
   version: 4.0.0
   resolution: "is-docker@npm:4.0.0"
   bin:
@@ -5915,7 +6206,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^30.2.0":
+"jest-diff@npm:30.2.0":
   version: 30.2.0
   resolution: "jest-diff@npm:30.2.0"
   dependencies:
@@ -6013,7 +6304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jszip@npm:^3.10.1":
+"jszip@npm:3.10.1, jszip@npm:^3.10.1":
   version: 3.10.1
   resolution: "jszip@npm:3.10.1"
   dependencies:
@@ -6344,6 +6635,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.2.1":
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
+  dependencies:
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^10.2.2, minimatch@npm:^10.2.3":
   version: 10.2.4
   resolution: "minimatch@npm:10.2.4"
@@ -6442,13 +6742,6 @@ __metadata:
   version: 7.1.2
   resolution: "minipass@npm:7.1.2"
   checksum: 10c0/b0fd20bb9fb56e5fa9a8bfac539e8915ae07430a619e4b86ff71f5fc757ef3924b23b2c4230393af1eda647ed3d75739e4e0acb250a6b1eb277cf7f8fe449557
-  languageName: node
-  linkType: hard
-
-"minipass@npm:^7.1.3":
-  version: 7.1.3
-  resolution: "minipass@npm:7.1.3"
-  checksum: 10c0/539da88daca16533211ea5a9ee98dc62ff5742f531f54640dd34429e621955e91cc280a91a776026264b7f9f6735947629f920944e9c1558369e8bf22eb33fbb
   languageName: node
   linkType: hard
 
@@ -6638,7 +6931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pac-proxy-agent@npm:^7.1.0":
+"pac-proxy-agent@npm:^7.0.1":
   version: 7.2.0
   resolution: "pac-proxy-agent@npm:7.2.0"
   dependencies:
@@ -6708,6 +7001,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-expression-matcher@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "path-expression-matcher@npm:1.2.0"
+  checksum: 10c0/86c661dfb265ed5dd1ddd9188f0dfbecf4ec4dc3ea6cabab081d3a2ba285054d9767a641a233bd6fd694fd89f7d0ef94913032feddf5365252700b02db4bf4e1
+  languageName: node
+  linkType: hard
+
 "path-is-absolute@npm:^1.0.0":
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
@@ -6729,16 +7029,6 @@ __metadata:
     lru-cache: "npm:^11.0.0"
     minipass: "npm:^7.1.2"
   checksum: 10c0/2a16ed0e81fbc43513e245aa5763354e25e787dab0d539581a6c3f0f967461a159ed6236b2559de23aa5b88e7dc32b469b6c47568833dd142a4b24b4f5cd2620
-  languageName: node
-  linkType: hard
-
-"path-scurry@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "path-scurry@npm:2.0.2"
-  dependencies:
-    lru-cache: "npm:^11.0.0"
-    minipass: "npm:^7.1.2"
-  checksum: 10c0/b35ad37cf6557a87fd057121ce2be7695380c9138d93e87ae928609da259ea0a170fac6f3ef1eb3ece8a068e8b7f2f3adf5bb2374cf4d4a57fe484954fcc9482
   languageName: node
   linkType: hard
 
@@ -6896,19 +7186,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-agent@npm:^6.4.0":
-  version: 6.5.0
-  resolution: "proxy-agent@npm:6.5.0"
+"proxy-agent@npm:6.4.0":
+  version: 6.4.0
+  resolution: "proxy-agent@npm:6.4.0"
   dependencies:
-    agent-base: "npm:^7.1.2"
+    agent-base: "npm:^7.0.2"
     debug: "npm:^4.3.4"
     http-proxy-agent: "npm:^7.0.1"
-    https-proxy-agent: "npm:^7.0.6"
+    https-proxy-agent: "npm:^7.0.3"
     lru-cache: "npm:^7.14.1"
-    pac-proxy-agent: "npm:^7.1.0"
+    pac-proxy-agent: "npm:^7.0.1"
     proxy-from-env: "npm:^1.1.0"
-    socks-proxy-agent: "npm:^8.0.5"
-  checksum: 10c0/7fd4e6f36bf17098a686d4aee3b8394abfc0b0537c2174ce96b0a4223198b9fafb16576c90108a3fcfc2af0168bd7747152bfa1f58e8fee91d3780e79aab7fd8
+    socks-proxy-agent: "npm:^8.0.2"
+  checksum: 10c0/0c5b85cacf67eec9d8add025a5e577b2c895672e4187079ec41b0ee2a6dacd90e69a837936cb3ac141dd92b05b50a325b9bfe86ab0dc3b904011aa3bcf406fc0
   languageName: node
   linkType: hard
 
@@ -7149,6 +7439,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:7.6.3":
+  version: 7.6.3
+  resolution: "semver@npm:7.6.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/88f33e148b210c153873cb08cfe1e281d518aaa9a666d4d148add6560db5cd3c582f3a08ccb91f38d5f379ead256da9931234ed122057f40bb5766e65e58adaf
+  languageName: node
+  linkType: hard
+
 "semver@npm:^7.3.5, semver@npm:^7.7.3, semver@npm:^7.7.4":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
@@ -7158,7 +7457,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.6, semver@npm:^7.5.3, semver@npm:^7.5.4":
+"semver@npm:^7.3.6, semver@npm:^7.5.4":
   version: 7.7.2
   resolution: "semver@npm:7.7.2"
   bin:
@@ -7178,8 +7477,8 @@ __metadata:
     "@aws-sdk/client-secrets-manager": "npm:~3.990.0"
     "@aws-sdk/s3-request-presigner": "npm:~3.990.0"
     "@datadog/datadog-api-client": "npm:^1.53.0"
-    "@datadog/datadog-ci-base": "npm:^5.9.1"
-    "@datadog/datadog-ci-plugin-lambda": "npm:^5.9.1"
+    "@datadog/datadog-ci-base": "npm:5.11.0"
+    "@datadog/datadog-ci-plugin-lambda": "npm:5.11.0"
     "@types/aws-lambda": "npm:^8.10.161"
     "@types/cfn-response": "npm:^1.0.9"
     "@types/lodash": "npm:^4.17.24"
@@ -7188,7 +7487,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.57.1"
     aws-cdk: "npm:^2.1112.0"
     aws-cdk-lib: "npm:^2.243.0"
-    axios: "npm:^1.13.6"
+    axios: "npm:1.13.5"
     cfn-response: "npm:^1.0.1"
     constructs: "npm:^10.5.1"
     esbuild: "npm:^0.27.4"
@@ -7280,7 +7579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^8.0.3, socks-proxy-agent@npm:^8.0.5":
+"socks-proxy-agent@npm:^8.0.2, socks-proxy-agent@npm:^8.0.3, socks-proxy-agent@npm:^8.0.5":
   version: 8.0.5
   resolution: "socks-proxy-agent@npm:8.0.5"
   dependencies:
@@ -7505,7 +7804,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-async-pool@npm:^2.1.0":
+"tiny-async-pool@npm:2.1.0":
   version: 2.1.0
   resolution: "tiny-async-pool@npm:2.1.0"
   checksum: 10c0/658a986a21442fc82ad51af98e86dff6e61f888450722f0bf8bde3a2cbaf0506aa9812ed088ee411881efe6b1e6eedecacd95251f847f46456d15974bf1b87b2
@@ -7636,7 +7935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typanion@npm:^3.14.0, typanion@npm:^3.8.0":
+"typanion@npm:3.14.0, typanion@npm:^3.8.0":
   version: 3.14.0
   resolution: "typanion@npm:3.14.0"
   checksum: 10c0/8b03b19844e6955bfd906c31dc781bae6d7f1fb3ce4fe24b7501557013d4889ae5cefe671dafe98d87ead0adceb8afcb8bc16df7dc0bd2b7331bac96f3a7cae2
@@ -7725,7 +8024,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"upath@npm:^2.0.1":
+"upath@npm:2.0.1":
   version: 2.0.1
   resolution: "upath@npm:2.0.1"
   checksum: 10c0/79e8e1296b00e24a093b077cfd7a238712d09290c850ce59a7a01458ec78c8d26dcc2ab50b1b9d6a84dabf6511fb4969afeb8a5c9a001aa7272b9cc74c34670f


### PR DESCRIPTION
## Summary

- Bumps `@datadog/datadog-ci-base` and `@datadog/datadog-ci-plugin-lambda` from `^5.9.1` to exact `5.11.0`
- Pins `axios` from `^1.13.6` to exact `1.13.5` (matching what `@datadog/datadog-ci-base@5.11.0` uses, avoiding duplicate copies in `node_modules`)

## Context

Following the [axios npm supply chain compromise](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan), `axios@1.14.1` was published with a RAT payload. The loose `^` ranges on both axios and datadog-ci-* would have allowed resolution to compromised versions on a fresh install. Exact pinning prevents this class of attack going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)