### PR TITLE
[SVLS-8827] add npm minimal age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,9 @@
 npmRegistryServer: "https://depot-read-api-npm.us1.ddbuild.io/internal/magicmirror/magicmirror"
 enableNetwork: true
 nodeLinker: node-modules
+
+npmMinimalAgeGate: "2d"
+
 networkSettings:
   "registry.npmjs.org":
     httpProxy: "http://0.0.0.0"


### PR DESCRIPTION
## What does this PR do?

Adds `npmMinimalAgeGate: "2d"` to `.yarnrc.yml` to refuse NPM packages published less than 2 days ago during lockfile generation.

## Motivation

Following the supply chain attack on axios, this hardens our dependency resolution by requiring a minimum age for NPM packages before they can be included in the lockfile. This is a config-only change with no functional impact.

## Jira ticket

[SVLS-8827](https://datadoghq.atlassian.net/browse/SVLS-8827)