### PR TITLE
chore: make integration test runner verbose

### DIFF
--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
     retry: process.env.CI ? 3 : 0,
     fileParallelism: false,
     globalSetup: ["./integration-tests/vitest-global-setup.ts"],
-    reporter: "verbose",
+    reporters: ["verbose"],
   },
 });

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
     retry: process.env.CI ? 3 : 0,
     fileParallelism: false,
     globalSetup: ["./integration-tests/vitest-global-setup.ts"],
+    reporter: "verbose",
   },
 });


### PR DESCRIPTION
Currently the test runner hold output until all tests in a suite are done, but this can be super long for integration tests. This pr makes it so the reporter logs as each test finishes in the integration tests.


Look at the integration tests in CI for this PR as an example:
<img width="1649" height="343" alt="image" src="https://github.com/user-attachments/assets/ce062ab5-cd51-47c2-9f38-3bd9468455b9" />
