### PR TITLE
chore: fix unawaited promise in integration test

### DIFF
--- a/integration-tests/lambda-management-events.test.ts
+++ b/integration-tests/lambda-management-events.test.ts
@@ -158,10 +158,9 @@ describe("Remote instrumenter lambda management event tests", () => {
     const areCorrectlyInstrumented = await pollUntilTrue(
       60000,
       5000,
-      () =>
-        // @ts-expect-error Need to fix later
-        isFunctionInstrumented(nodejsFunctionName) &&
-        isFunctionUninstrumented(pythonFunctionName),
+      async () =>
+        (await isFunctionInstrumented(nodejsFunctionName)) &&
+        (await isFunctionUninstrumented(pythonFunctionName)),
     );
 
     // The functions are instrumented and uninstrumented respectively


### PR DESCRIPTION
### What does this PR do?

Fixes an unawaited promise in the "can instrument a lambda function by its runtime" integration test. The `&&` between two `Promise<boolean>` values was not awaiting the left operand -- since a Promise is truthy, only the right-hand promise was actually returned and awaited. The left-hand `isFunctionInstrumented()` call ran fire-and-forget.

### Motivation

This caused intermittent unhandled `ResourceNotFoundException` rejections when the fire-and-forget promise resolved after `afterEach` had already deleted the test function. Vitest (unlike Jest) treats unhandled rejections as fatal, marking the pipeline as failed even when all tests pass ([example: all 37 tests pass but pipeline fails](https://gitlab.ddbuild.io/DataDog/serverless-remote-instrumentation/-/jobs/1565703439)). This led to a cascade where stale Lambda functions accumulated and blocked all subsequent self-monitoring runs with `ResourceConflictException` ([example](https://gitlab.ddbuild.io/DataDog/serverless-remote-instrumentation/-/jobs/1599397737)).

[Self-monitoring pipelines](https://gitlab.ddbuild.io/DataDog/serverless-remote-instrumentation/-/pipelines?page=1&scope=all) have been failing since ~April 3. The 184 stale Lambda functions have been manually cleaned up in ap-south-1.


### Testing Guidelines

Self-monitoring pipeline should go green after this merges.

### Additional Notes

The `@ts-expect-error` comment (with a "fix later" note) has been there since the [vitest migration (#231)](https://github.com/DataDog/serverless-remote-instrumentation/pull/231) -- this resolves it.