### PR TITLE
chore: handle stale lambda functions in integration tests

### DIFF
--- a/integration-tests/utilities/lambda-functions.ts
+++ b/integration-tests/utilities/lambda-functions.ts
@@ -5,6 +5,7 @@ import {
   DeleteFunctionCommand,
   GetFunctionConfigurationCommand,
   InvokeCommand,
+  ResourceConflictException,
   ResourceNotFoundException,
   Runtime,
   TagResourceCommand,
@@ -51,7 +52,20 @@ const createFunctions = async (
       ...lambdaProps,
     });
 
-    const lambda = await lambdaClient.send(command);
+    let lambda;
+    try {
+      lambda = await lambdaClient.send(command);
+    } catch (e) {
+      if (e instanceof ResourceConflictException) {
+        // Stale function from a previous run -- delete and recreate
+        await lambdaClient.send(
+          new DeleteFunctionCommand({ FunctionName: functionName }),
+        );
+        lambda = await lambdaClient.send(command);
+      } else {
+        throw e;
+      }
+    }
     createdFunctions.add(lambda);
     functionNamesToCleanUp.push(lambda.FunctionName);
   }


### PR DESCRIPTION
### What does this PR do?

When `createFunction` in integration tests hits a `ResourceConflictException` (function already exists), it now deletes the stale function and retries the create instead of failing the test.

### Motivation

Stacked on [#247](https://github.com/DataDog/serverless-remote-instrumentation/pull/247). Even with the root cause fixed, if a pipeline run is ever interrupted (cancelled, timed out, infra issue) and leaves behind Lambda functions, every subsequent self-monitoring run would fail permanently with `ResourceConflictException`. This makes the tests self-healing in that scenario.

### Testing Guidelines

Self-monitoring pipeline should continue to pass even if stale functions exist from a previous interrupted run.

### Additional Notes

N/A