### PR TITLE
chore: remove stale as any casts

### DIFF
--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -146,8 +146,6 @@ export async function instrumentWithDatadogCi(
           | "latest"
           | "none",
       };
-      // Type assertions needed: the plugin pins @aws-sdk/client-lambda@3.981.0
-      // whose @smithy/types are structurally incompatible with ours at runtime
       functionConfig = await getInstrumentedFunctionConfig(
         lambdaClient,
         cloudWatchLogsClient,

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -149,24 +149,24 @@ export async function instrumentWithDatadogCi(
       // Type assertions needed: the plugin pins @aws-sdk/client-lambda@3.981.0
       // whose @smithy/types are structurally incompatible with ours at runtime
       functionConfig = await getInstrumentedFunctionConfig(
-        lambdaClient as any,
-        cloudWatchLogsClient as any,
+        lambdaClient,
+        cloudWatchLogsClient,
         functionToInstrument,
         process.env.AWS_REGION!,
         settings,
       );
     } else {
       functionConfig = await getUninstrumentedFunctionConfig(
-        lambdaClient as any,
-        cloudWatchLogsClient as any,
+        lambdaClient,
+        cloudWatchLogsClient,
         functionToInstrument,
         undefined, // forwarderARN
       );
     }
 
     await updateLambdaFunctionConfig(
-      lambdaClient as any,
-      cloudWatchLogsClient as any,
+      lambdaClient,
+      cloudWatchLogsClient,
       functionConfig,
     );
   } catch (error) {


### PR DESCRIPTION
### What does this PR do?

Removes `as any` type assertions from `lambdaClient` and `cloudWatchLogsClient` when passed to `getInstrumentedFunctionConfig`, `getUninstrumentedFunctionConfig`, and `updateLambdaFunctionConfig`.

### Motivation

The `as any` casts were originally added to work around structural type incompatibilities between the pinned `@aws-sdk/client-lambda@3.981.0` plugin dependency and our `@smithy/types` versions. These type assertions are no longer necessary and removing them improves type safety.

### Testing Guidelines

Existing tests should confirm that removing the type assertions does not introduce any runtime or compilation issues.