### PR TITLE
[SVLS-8973] Add us2 gov site option

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -58,7 +58,7 @@ Parameters:
     Type: String
     Default: datadoghq.com
     Description: >-
-      The Datadog site where data will be sent. Possible values are `datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`.
+      The Datadog site where data will be sent. Possible values are `datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, `ap2.datadoghq.com`, `us2.ddog-gov.com`.
     AllowedPattern: .+
     ConstraintDescription: DdSite is required
   BucketName:


### PR DESCRIPTION
Add us2.ddog-gov.com as a site option