### PR TITLE
Fix release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "format": "oxlint --fix && prettier --write .",
     "lint": "oxlint && prettier --check .",
     "lint-yaml": "prettier --check .",
-    "create-release": "bash scripts/create_release.sh $1",
+    "create-release": "bash scripts/create_release.sh",
     "test": "vitest run --config vitest.config.ts",
     "integ": "vitest run --config integration-tests/vitest.config.ts",
     "metrics-validations": "vitest run --config metrics-validations/vitest.config.ts",


### PR DESCRIPTION
### What does this PR do?
With the latest yarn upgrade the release script got broken since the arguments are more automatically passed down when running yarn commands so we don't need the `$1`.  

### Motivation
Fixing the release command

### Testing Guidelines
This was tested for the last release - https://github.com/DataDog/serverless-remote-instrumentation/pull/255/s

