### PR TITLE
Fix metrics validation

### DIFF
--- a/metrics-validations/get-dd-metric-value.ts
+++ b/metrics-validations/get-dd-metric-value.ts
@@ -5,7 +5,6 @@ import {
   getApiKey,
   getAppKey,
 } from "../integration-tests/utilities/datadog-keys";
-import { get } from "lodash";
 
 const { account, region, functionName, ddSite } = config;
 
@@ -68,9 +67,15 @@ const getDDMetricValue = async ({
   };
   const result = await metricsClient.queryScalarData(query);
   const metricValue = result.data?.attributes?.columns?.find(
-    (item) => get(item, "name") === "metricValue",
+    (item) => (item as Record<string, unknown>)["name"] === "metricValue",
   );
-  return get(metricValue, ["values", 0], 0);
+  return (
+    (
+      (metricValue as Record<string, unknown> | undefined)?.["values"] as
+        | unknown[]
+        | undefined
+    )?.[0] ?? 0
+  );
 };
 
 export default getDDMetricValue;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@datadog/datadog-api-client": "^1.53.0",
     "@types/aws-lambda": "^8.10.161",
     "@types/cfn-response": "^1.0.9",
-    "@types/lodash": "^4.17.24",
     "@types/node": "^25.5.0",
     "aws-cdk": "^2.1118.0",
     "aws-cdk-lib": "^2.249.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,13 +2237,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4.17.24":
-  version: 4.17.24
-  resolution: "@types/lodash@npm:4.17.24"
-  checksum: 10c0/b72f60d4daacdad1fa643edb3faba204c02a01eb1ac00a83ff73496a6d236fc55e459c06106e8ced42277dba932d087d8fc090f8de4ef590d3f91e6d6f7ce85a
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:*, @types/node@npm:^25.5.0":
   version: 25.5.0
   resolution: "@types/node@npm:25.5.0"
@@ -3894,7 +3887,6 @@ __metadata:
     "@smithy/util-retry": "npm:2.2.0"
     "@types/aws-lambda": "npm:^8.10.161"
     "@types/cfn-response": "npm:^1.0.9"
-    "@types/lodash": "npm:^4.17.24"
     "@types/node": "npm:^25.5.0"
     aws-cdk: "npm:^2.1118.0"
     aws-cdk-lib: "npm:^2.249.0"


### PR DESCRIPTION
### What does this PR do?
Fix the metrics validation step, which failed because lodash got removed in a previous PR.  This was easy enough for claude to just replace the usage with native JS and remove the dependency.


### Motivation
Failed run - https://gitlab.ddbuild.io/DataDog/serverless-remote-instrumentation/-/jobs/1642858821

### Testing Guidelines
Ran metrics validation locally, as a follow up to this after that release is out I can add it to the PR workflow too.  Will redo the release after this is merged

