### PR TITLE
Release v2.4.0

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -5,7 +5,7 @@ Description: Datadog Lambda Remote Instrumentation App
 Mappings:
   Constants:
     DdRemoteInstrumentApp:
-      Version: 2.3.0
+      Version: 2.4.0
     DdRemoteInstrumentLayerAwsAccount:
       Number: 464622532012
     InstrumenterFunctionName:


### PR DESCRIPTION
This release includes the following commits:
2a78db4 chore: manual dependency update while adms is blocked (#259)
ae72677 [SVLS-9011] fix integration tests for duplicate config prevention (#258)


[SVLS-9011]: https://datadoghq.atlassian.net/browse/SVLS-9011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ