### PR TITLE
Add metric for time to instrument

### DIFF
--- a/integration-tests/infrastructure/bin/infrastructure.ts
+++ b/integration-tests/infrastructure/bin/infrastructure.ts
@@ -77,7 +77,7 @@ class TestingStack extends Stack {
     // Timeout at 5 minutes since sometimes we run into cases where the custom resource hangs.
     template.Resources.CloudFormationLifeCycle.Properties.ServiceTimeout = 300;
     template.Mappings.Constants.DdCIBypassSiteValidation.Bypass = true;
-    template.Mappings.Constants.SendDebugInformation.Enabled = true;
+    template.Mappings.Constants.DdInternalSendDebugInformation.Enabled = true;
     writeFileSync(modifiedPath, yamlDump(template));
     return modifiedPath;
   }

--- a/integration-tests/infrastructure/bin/infrastructure.ts
+++ b/integration-tests/infrastructure/bin/infrastructure.ts
@@ -77,6 +77,7 @@ class TestingStack extends Stack {
     // Timeout at 5 minutes since sometimes we run into cases where the custom resource hangs.
     template.Resources.CloudFormationLifeCycle.Properties.ServiceTimeout = 300;
     template.Mappings.Constants.DdCIBypassSiteValidation.Bypass = true;
+    template.Mappings.Constants.SendDebugInformation.Enabled = true;
     writeFileSync(modifiedPath, yamlDump(template));
     return modifiedPath;
   }

--- a/integration-tests/load-tests.test.ts
+++ b/integration-tests/load-tests.test.ts
@@ -1,0 +1,52 @@
+import {
+  describe,
+  it,
+  expect,
+  afterAll,
+  beforeAll,
+} from "vitest";
+
+import { pollUntilTrue } from "./utilities/poll-until-true";
+import { isFunctionInstrumented } from "./utilities/is-function-instrumented";
+import {
+  setRemoteConfig,
+  clearRemoteConfigs,
+  clearKnownRemoteConfigs,
+} from "./utilities/remote-config";
+import {
+  createFunctions,
+  deleteTestFunctions,
+} from "./utilities/lambda-functions";
+
+const RUN_LOAD_TESTS = process.env.RUN_LOAD_TESTS === "true";
+
+describe.skipIf(!RUN_LOAD_TESTS)(
+  "Remote instrumenter load tests",
+  () => {
+    beforeAll(async () => {
+      await clearRemoteConfigs();
+    }, 300_000);
+
+    afterAll(async () => {
+      await deleteTestFunctions();
+      await clearKnownRemoteConfigs();
+    }, 300_000);
+
+    it("can handle many lambda management events", async () => {
+      await setRemoteConfig();
+
+      const NUM_FUNCTIONS = 100;
+      const functions = await createFunctions({ Tags: { foo: "bar" } }, NUM_FUNCTIONS);
+      const functionNames = functions.map((f) => f.FunctionName);
+
+      const results = await Promise.all(
+        functionNames.map((functionName) =>
+          pollUntilTrue(1200000, 5000, () => isFunctionInstrumented(functionName)),
+        ),
+      );
+
+      const allInstrumented = results.every(Boolean);
+      expect(allInstrumented).toStrictEqual(true);
+    }, 1200_000);
+  },
+);

--- a/integration-tests/load-tests.test.ts
+++ b/integration-tests/load-tests.test.ts
@@ -1,10 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  afterAll,
-  beforeAll,
-} from "vitest";
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
 
 import { pollUntilTrue } from "./utilities/poll-until-true";
 import { isFunctionInstrumented } from "./utilities/is-function-instrumented";
@@ -20,33 +14,35 @@ import {
 
 const RUN_LOAD_TESTS = process.env.RUN_LOAD_TESTS === "true";
 
-describe.skipIf(!RUN_LOAD_TESTS)(
-  "Remote instrumenter load tests",
-  () => {
-    beforeAll(async () => {
-      await clearRemoteConfigs();
-    }, 300_000);
+describe.skipIf(!RUN_LOAD_TESTS)("Remote instrumenter load tests", () => {
+  beforeAll(async () => {
+    await clearRemoteConfigs();
+  }, 300_000);
 
-    afterAll(async () => {
-      await deleteTestFunctions();
-      await clearKnownRemoteConfigs();
-    }, 300_000);
+  afterAll(async () => {
+    await deleteTestFunctions();
+    await clearKnownRemoteConfigs();
+  }, 300_000);
 
-    it("can handle many lambda management events", async () => {
-      await setRemoteConfig();
+  it("can handle many lambda management events", async () => {
+    await setRemoteConfig();
 
-      const NUM_FUNCTIONS = 100;
-      const functions = await createFunctions({ Tags: { foo: "bar" } }, NUM_FUNCTIONS);
-      const functionNames = functions.map((f) => f.FunctionName);
+    const NUM_FUNCTIONS = 100;
+    const functions = await createFunctions(
+      { Tags: { foo: "bar" } },
+      NUM_FUNCTIONS,
+    );
+    const functionNames = functions.map((f) => f.FunctionName);
 
-      const results = await Promise.all(
-        functionNames.map((functionName) =>
-          pollUntilTrue(1200000, 5000, () => isFunctionInstrumented(functionName)),
+    const results = await Promise.all(
+      functionNames.map((functionName) =>
+        pollUntilTrue(1200000, 5000, () =>
+          isFunctionInstrumented(functionName),
         ),
-      );
+      ),
+    );
 
-      const allInstrumented = results.every(Boolean);
-      expect(allInstrumented).toStrictEqual(true);
-    }, 1200_000);
-  },
-);
+    const allInstrumented = results.every(Boolean);
+    expect(allInstrumented).toStrictEqual(true);
+  }, 1200_000);
+});

--- a/integration-tests/utilities/remote-config.ts
+++ b/integration-tests/utilities/remote-config.ts
@@ -195,7 +195,7 @@ const deleteRemoteConfig = async (id: string): Promise<any> => {
       "dd-application-key": appKey,
     },
   });
-  if (!response.ok) {
+  if (!response.ok && response.status !== 404) {
     throw new Error(`HTTP ${response.status}`);
   }
   return response;

--- a/integration-tests/utilities/remote-instrumenter-invocations.ts
+++ b/integration-tests/utilities/remote-instrumenter-invocations.ts
@@ -47,6 +47,7 @@ const invokeLambdaWithLambdaManagementEvent = async ({
         },
       },
       source: "aws.lambda",
+      time: new Date().toISOString(),
       name: `integration-tests${process.env.USER}`,
     }),
   });

--- a/integration-tests/utilities/remote-instrumenter-invocations.ts
+++ b/integration-tests/utilities/remote-instrumenter-invocations.ts
@@ -47,7 +47,6 @@ const invokeLambdaWithLambdaManagementEvent = async ({
         },
       },
       source: "aws.lambda",
-      time: new Date().toISOString(),
       name: `integration-tests${process.env.USER}`,
     }),
   });

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "create-release": "bash scripts/create_release.sh",
     "test": "vitest run --config vitest.config.ts",
     "integ": "vitest run --config integration-tests/vitest.config.ts",
+    "integ-load": "RUN_LOAD_TESTS=true vitest run --config integration-tests/vitest.config.ts integration-tests/load-tests.test.ts",
     "metrics-validations": "vitest run --config metrics-validations/vitest.config.ts",
     "integ-test-setup": "bash -c 'if [ -n \"$CI_PROJECT_DIR\" ]; then node ${SCRIPTS_PATH}/test_setup.js; else node scripts/test_setup.js; fi'",
     "integ-test-teardown": "bash -c 'if [ -n \"$CI_PROJECT_DIR\" ]; then node ${SCRIPTS_PATH}/test_teardown.js; else node scripts/test_teardown.js; fi'"

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -166,6 +166,10 @@ export const DD_KMS_API_KEY = "DD_KMS_API_KEY";
 export const DD_API_KEY_SECRET_ARN = "DD_API_KEY_SECRET_ARN";
 export const DD_API_KEY_SSM_ARN = "DD_API_KEY_SSM_ARN";
 export const DD_SITE = "DD_SITE";
+export const DD_INTERNAL_SEND_DEBUG_INFORMATION =
+  "DD_INTERNAL_SEND_DEBUG_INFORMATION";
+export const INSTRUMENTATION_LATENCY_METRIC =
+  "datadog.remote_instrumenter.lambda_management_event.instrumentation_latency";
 
 // Remote config constants
 export const RC_PRODUCT = "SERVERLESS_REMOTE_INSTRUMENTATION";

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -170,6 +170,10 @@ export const DD_INTERNAL_SEND_DEBUG_INFORMATION =
   "DD_INTERNAL_SEND_DEBUG_INFORMATION";
 export const INSTRUMENTATION_LATENCY_METRIC =
   "datadog.remote_instrumenter.lambda_management_event.instrumentation_latency";
+export const EVENTBRIDGE_DELAY_METRIC =
+  "datadog.remote_instrumenter.lambda_management_event.eventbridge_delay";
+export const LAMBDA_PROCESSING_LATENCY_METRIC =
+  "datadog.remote_instrumenter.lambda_management_event.lambda_processing_latency";
 
 // Remote config constants
 export const RC_PRODUCT = "SERVERLESS_REMOTE_INSTRUMENTATION";

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -39,7 +39,7 @@ import {
   getTaggingClient,
 } from "./aws-resources";
 import { instrumentFunctions } from "./instrument";
-import { submitInstrumentationLatency } from "./metrics";
+import { submitInstrumentationMetrics } from "./metrics";
 import {
   LAMBDA_EVENT,
   SCHEDULED_INVOCATION_EVENT,
@@ -63,6 +63,7 @@ export const handler = async (
   event: InstrumenterEvent,
   context: Context,
 ): Promise<InstrumentOutcome> => {
+  const invocationStartedAt = new Date();
   logger.logObject(selectEventFieldsForLogging(event));
   const instrumentOutcome: InstrumentOutcome = {
     instrument: { succeeded: {}, failed: {}, skipped: {} },
@@ -169,8 +170,18 @@ export const handler = async (
       const anySucceeded =
         Object.keys(instrumentOutcome.instrument.succeeded).length > 0;
       if (eventTime && anySucceeded) {
-        const deltaMs = instrumentedAt.getTime() - eventTime.getTime();
-        await submitInstrumentationLatency(deltaMs, context.invokedFunctionArn);
+        const instrumentationLatencyMs =
+          instrumentedAt.getTime() - eventTime.getTime();
+        const eventbridgeDelayMs =
+          invocationStartedAt.getTime() - eventTime.getTime();
+        const lambdaProcessingLatencyMs =
+          instrumentedAt.getTime() - invocationStartedAt.getTime();
+        await submitInstrumentationMetrics(
+          instrumentationLatencyMs,
+          eventbridgeDelayMs,
+          lambdaProcessingLatencyMs,
+          context.invokedFunctionArn,
+        );
       }
     }
   }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -48,6 +48,7 @@ import {
   FUNCTION_NOT_FOUND,
   INSTRUMENT,
   SKIPPED,
+  DD_INTERNAL_SEND_DEBUG_INFORMATION,
   type LambdaFunction,
   type UnenrichedLambdaFunction,
   type InstrumentOutcome,
@@ -162,13 +163,12 @@ export const handler = async (
       LAMBDA_EVENT,
     );
 
-    if (process.env.DD_INTERNAL_SEND_DEBUG_INFORMATION === "true") {
+    if (process.env[DD_INTERNAL_SEND_DEBUG_INFORMATION] === "true") {
       const instrumentedAt = new Date();
       const eventTime = event.time ? new Date(event.time) : null;
-      const allSkipped =
-        Object.keys(instrumentOutcome.instrument.succeeded).length === 0 &&
-        Object.keys(instrumentOutcome.instrument.failed).length === 0;
-      if (eventTime && !allSkipped) {
+      const anySucceeded =
+        Object.keys(instrumentOutcome.instrument.succeeded).length > 0;
+      if (eventTime && anySucceeded) {
         const deltaMs = instrumentedAt.getTime() - eventTime.getTime();
         await submitInstrumentationLatency(deltaMs, context.invokedFunctionArn);
       }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -162,7 +162,7 @@ export const handler = async (
       LAMBDA_EVENT,
     );
 
-    if (process.env.DD_SEND_DEBUG_INFORMATION === "true") {
+    if (process.env.DD_INTERNAL_SEND_DEBUG_INFORMATION === "true") {
       const instrumentedAt = new Date();
       const eventTime = event.time ? new Date(event.time) : null;
       const allSkipped =

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -39,6 +39,7 @@ import {
   getTaggingClient,
 } from "./aws-resources";
 import { instrumentFunctions } from "./instrument";
+import { submitInstrumentationLatency } from "./metrics";
 import {
   LAMBDA_EVENT,
   SCHEDULED_INVOCATION_EVENT,
@@ -160,6 +161,18 @@ export const handler = async (
       taggingClient,
       LAMBDA_EVENT,
     );
+
+    if (process.env.DD_SEND_DEBUG_INFORMATION === "true") {
+      const instrumentedAt = new Date();
+      const eventTime = event.time ? new Date(event.time) : null;
+      const allSkipped =
+        Object.keys(instrumentOutcome.instrument.succeeded).length === 0 &&
+        Object.keys(instrumentOutcome.instrument.failed).length === 0;
+      if (eventTime && !allSkipped) {
+        const deltaMs = instrumentedAt.getTime() - eventTime.getTime();
+        await submitInstrumentationLatency(deltaMs, context.invokedFunctionArn);
+      }
+    }
   }
 
   // Else if it's a scheduled event, check if the config has changed and instrument all functions

--- a/src/lambda-event.ts
+++ b/src/lambda-event.ts
@@ -23,6 +23,7 @@ export interface CloudFormationEvent {
 export interface LambdaManagementEvent {
   "detail-type": string;
   source: string;
+  time?: string;
   detail: {
     eventName: string;
     requestParameters?: {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,12 +1,12 @@
-import { request } from "https";
+import { DD_API_KEY, DD_SITE, INSTRUMENTATION_LATENCY_METRIC } from "./consts";
 import { logger } from "./logger";
 
 export async function submitInstrumentationLatency(
   deltaMs: number,
   functionArn: string,
 ): Promise<void> {
-  const apiKey = process.env.DD_API_KEY;
-  const site = process.env.DD_SITE ?? "datadoghq.com";
+  const apiKey = process.env[DD_API_KEY];
+  const site = process.env[DD_SITE] ?? "datadoghq.com";
 
   if (!apiKey) {
     logger.warn("DD_API_KEY not set, skipping metric submission");
@@ -17,46 +17,32 @@ export async function submitInstrumentationLatency(
   const body = JSON.stringify({
     series: [
       {
-        metric:
-          "datadog.remote_instrumenter.lambda_management_event.instrumentation_latency",
+        metric: INSTRUMENTATION_LATENCY_METRIC,
         points: [[nowSec, [deltaMs]]],
         tags: functionArn ? [`function_arn:${functionArn}`] : [],
       },
     ],
   });
 
-  return new Promise((resolve) => {
-    const req = request(
+  try {
+    const response = await fetch(
+      `https://api.${site}/api/v1/distribution_points`,
       {
-        hostname: `api.${site}`,
-        path: "/api/v1/distribution_points",
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           "DD-API-KEY": apiKey,
         },
-      },
-      (res) => {
-        const chunks: Buffer[] = [];
-        res.on("data", (chunk) => chunks.push(chunk));
-        res.on("end", () => {
-          const responseBody = Buffer.concat(chunks).toString();
-          if (res.statusCode && res.statusCode >= 400) {
-            logger.warn(
-              `Failed to submit instrumentation latency metric: HTTP ${res.statusCode} ${responseBody}`,
-            );
-          }
-          resolve();
-        });
+        body,
       },
     );
-
-    req.on("error", (error) => {
-      logger.warn(`Failed to submit instrumentation latency metric: ${error}`);
-      resolve();
-    });
-
-    req.write(body);
-    req.end();
-  });
+    if (!response.ok) {
+      const responseBody = await response.text();
+      logger.warn(
+        `Failed to submit instrumentation latency metric: HTTP ${response.status} ${responseBody}`,
+      );
+    }
+  } catch (error) {
+    logger.warn(`Failed to submit instrumentation latency metric: ${error}`);
+  }
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -17,7 +17,8 @@ export async function submitInstrumentationLatency(
   const body = JSON.stringify({
     series: [
       {
-        metric: "datadog.remote_instrumenter.lambda_management_event.instrumentation_latency",
+        metric:
+          "datadog.remote_instrumenter.lambda_management_event.instrumentation_latency",
         points: [[nowSec, [deltaMs]]],
         tags: functionArn ? [`function_arn:${functionArn}`] : [],
       },

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,61 @@
+import { request } from "https";
+import { logger } from "./logger";
+
+export async function submitInstrumentationLatency(
+  deltaMs: number,
+  functionArn: string,
+): Promise<void> {
+  const apiKey = process.env.DD_API_KEY;
+  const site = process.env.DD_SITE ?? "datadoghq.com";
+
+  if (!apiKey) {
+    logger.warn("DD_API_KEY not set, skipping metric submission");
+    return;
+  }
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const body = JSON.stringify({
+    series: [
+      {
+        metric: "datadog.remote_instrumenter.lambda_management_event.instrumentation_latency",
+        points: [[nowSec, [deltaMs]]],
+        tags: functionArn ? [`function_arn:${functionArn}`] : [],
+      },
+    ],
+  });
+
+  return new Promise((resolve) => {
+    const req = request(
+      {
+        hostname: `api.${site}`,
+        path: "/api/v1/distribution_points",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "DD-API-KEY": apiKey,
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => {
+          const responseBody = Buffer.concat(chunks).toString();
+          if (res.statusCode && res.statusCode >= 400) {
+            logger.warn(
+              `Failed to submit instrumentation latency metric: HTTP ${res.statusCode} ${responseBody}`,
+            );
+          }
+          resolve();
+        });
+      },
+    );
+
+    req.on("error", (error) => {
+      logger.warn(`Failed to submit instrumentation latency metric: ${error}`);
+      resolve();
+    });
+
+    req.write(body);
+    req.end();
+  });
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,9 +1,20 @@
-import { DD_API_KEY, DD_SITE, INSTRUMENTATION_LATENCY_METRIC } from "./consts";
+import {
+  DD_API_KEY,
+  DD_SITE,
+  EVENTBRIDGE_DELAY_METRIC,
+  INSTRUMENTATION_LATENCY_METRIC,
+  LAMBDA_PROCESSING_LATENCY_METRIC,
+} from "./consts";
 import { logger } from "./logger";
 
-export async function submitInstrumentationLatency(
-  deltaMs: number,
-  functionArn: string,
+interface DistributionPoint {
+  metric: string;
+  value: number;
+  tags: string[];
+}
+
+async function submitDistributionPoints(
+  points: DistributionPoint[],
 ): Promise<void> {
   const apiKey = process.env[DD_API_KEY];
   const site = process.env[DD_SITE] ?? "datadoghq.com";
@@ -15,13 +26,11 @@ export async function submitInstrumentationLatency(
 
   const nowSec = Math.floor(Date.now() / 1000);
   const body = JSON.stringify({
-    series: [
-      {
-        metric: INSTRUMENTATION_LATENCY_METRIC,
-        points: [[nowSec, [deltaMs]]],
-        tags: functionArn ? [`function_arn:${functionArn}`] : [],
-      },
-    ],
+    series: points.map(({ metric, value, tags }) => ({
+      metric,
+      points: [[nowSec, [value]]],
+      tags,
+    })),
   });
 
   try {
@@ -39,10 +48,32 @@ export async function submitInstrumentationLatency(
     if (!response.ok) {
       const responseBody = await response.text();
       logger.warn(
-        `Failed to submit instrumentation latency metric: HTTP ${response.status} ${responseBody}`,
+        `Failed to submit metrics: HTTP ${response.status} ${responseBody}`,
       );
     }
   } catch (error) {
-    logger.warn(`Failed to submit instrumentation latency metric: ${error}`);
+    logger.warn(`Failed to submit metrics: ${error}`);
   }
+}
+
+export async function submitInstrumentationMetrics(
+  instrumentationLatencyMs: number,
+  eventbridgeDelayMs: number,
+  lambdaProcessingLatencyMs: number,
+  functionArn: string,
+): Promise<void> {
+  const tags = functionArn ? [`function_arn:${functionArn}`] : [];
+  await submitDistributionPoints([
+    {
+      metric: INSTRUMENTATION_LATENCY_METRIC,
+      value: instrumentationLatencyMs,
+      tags,
+    },
+    { metric: EVENTBRIDGE_DELAY_METRIC, value: eventbridgeDelayMs, tags },
+    {
+      metric: LAMBDA_PROCESSING_LATENCY_METRIC,
+      value: lambdaProcessingLatencyMs,
+      tags,
+    },
+  ]);
 }

--- a/template.yaml
+++ b/template.yaml
@@ -15,7 +15,7 @@ Mappings:
       Version: {CURRENT_LAYER_VERSION}
     DdCIBypassSiteValidation:
       Bypass: false
-    SendDebugInformation:
+    DdInternalSendDebugInformation:
       Enabled: false
 
 Metadata:
@@ -141,7 +141,7 @@ Resources:
           DD_EXTENSION_VERSION: compatibility
           DD_TAGS: !Join ["", ["template_version:", !FindInMap [ Constants, DdRemoteInstrumentApp, Version ]] ]
           DD_INSTRUMENTER_VERSION: !FindInMap [ Constants, DdRemoteInstrumentApp, Version ]
-          DD_INTERNAL_SEND_DEBUG_INFORMATION: !FindInMap [ Constants, SendDebugInformation, Enabled ]
+          DD_INTERNAL_SEND_DEBUG_INFORMATION: !FindInMap [ Constants, DdInternalSendDebugInformation, Enabled ]
       Tags:
         - Key: "dd_serverless_service"
           Value: "remote_instrumenter"

--- a/template.yaml
+++ b/template.yaml
@@ -141,7 +141,7 @@ Resources:
           DD_EXTENSION_VERSION: compatibility
           DD_TAGS: !Join ["", ["template_version:", !FindInMap [ Constants, DdRemoteInstrumentApp, Version ]] ]
           DD_INSTRUMENTER_VERSION: !FindInMap [ Constants, DdRemoteInstrumentApp, Version ]
-          DD_SEND_DEBUG_INFORMATION: !FindInMap [ Constants, SendDebugInformation, Enabled ]
+          DD_INTERNAL_SEND_DEBUG_INFORMATION: !FindInMap [ Constants, SendDebugInformation, Enabled ]
       Tags:
         - Key: "dd_serverless_service"
           Value: "remote_instrumenter"

--- a/template.yaml
+++ b/template.yaml
@@ -15,6 +15,8 @@ Mappings:
       Version: {CURRENT_LAYER_VERSION}
     DdCIBypassSiteValidation:
       Bypass: false
+    SendDebugInformation:
+      Enabled: false
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -139,6 +141,7 @@ Resources:
           DD_EXTENSION_VERSION: compatibility
           DD_TAGS: !Join ["", ["template_version:", !FindInMap [ Constants, DdRemoteInstrumentApp, Version ]] ]
           DD_INSTRUMENTER_VERSION: !FindInMap [ Constants, DdRemoteInstrumentApp, Version ]
+          DD_SEND_DEBUG_INFORMATION: !FindInMap [ Constants, SendDebugInformation, Enabled ]
       Tags:
         - Key: "dd_serverless_service"
           Value: "remote_instrumenter"


### PR DESCRIPTION
### What does this PR do?
Add a mapping in the template for internal metrics that we can use for self monitoring.  Include a metric about the time between a lambda management event and the instrumenter applying instrumentation to it, if anything was applied.

Also include a fix for self monitoring since the runs were failing because the delete returned a 404, which is fine.

### Motivation
We didn't have a way to know how quickly the instrumenter would re instrument customer lambda functions after their IaC updated it, this gives us a metric to see that as well as a way to test that under higher load than expected.


### Testing Guidelines
1. With this change we can run `yarn integ-load` to set the remote config rule and create a lot of lambdas very quickly.
2. See the [dashboard in staging](https://dd.datad0g.com/metric/explorer?fromUser=false&graph_layout=stacked&start=1780921720268&end=1780925320268&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMjJCBhQODAAdEaqOAhwTqIaBXjqIh3aTZiqAEbJTh6R8P0ITnAVcANN3b2znpIiTpgdIplYwABUPCA8ALpUru54mKHhV6o3GDGl8acXID1YaDmg8hg-BAdZQNGBOTK3DQQTKJNCiTpyRTKdJwqCw+FOehMZQiNweNCnfgQeyYLBORE5EBwkRKc48PifeRwhAAYSkwhgKBENzQPCAA) for the metric values



