### PR TITLE
Fix: treat : and _ as interchangeable in tag key matching [SVLS-9342]

### DIFF
--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -412,6 +412,36 @@ describe("Remote instrumenter scheduled event tests", () => {
     expect(isInstrumented).toStrictEqual(true);
   });
 
+  it("instruments a function whose tag key uses colons when the rule filter uses underscores (REDAPL normalization)", async () => {
+    // REDAPL converts colons in tag keys to underscores. A customer whose Lambda is tagged
+    // aws:cloudformation:stack-name=my-stack will see the rule filter displayed in the
+    // Datadog UI as aws_cloudformation_stack-name. The instrumenter must treat _ and :
+    // as interchangeable so that functions shown as eligible in the UI are actually instrumented.
+    const { FunctionName: functionName } = await createFunction({
+      Tags: { "aws:cloudformation:stack-name": "my-stack" },
+    });
+
+    await setRemoteConfig({
+      ruleFilters: [
+        {
+          key: "aws_cloudformation_stack-name",
+          values: ["my-stack"],
+          filter_type: "tag",
+          allow: true,
+        },
+      ],
+    });
+
+    const res = await invokeLambdaWithScheduledEvent();
+
+    expect(Object.keys(res.instrument.skipped)).not.toContain(functionName);
+
+    const isInstrumented = await pollUntilTrue(60000, 5000, () =>
+      isFunctionInstrumented(functionName),
+    );
+    expect(isInstrumented).toStrictEqual(true);
+  });
+
   it("can remove tags from functions that should not have them", async () => {
     const { FunctionName: functionName, FunctionArn: functionArn } =
       await createFunction({

--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -414,18 +414,19 @@ describe("Remote instrumenter scheduled event tests", () => {
 
   it("instruments a function whose tag key uses colons when the rule filter uses underscores (REDAPL normalization)", async () => {
     // REDAPL converts colons in tag keys to underscores. A customer whose Lambda is tagged
-    // aws:cloudformation:stack-name=my-stack will see the rule filter displayed in the
-    // Datadog UI as aws_cloudformation_stack-name. The instrumenter must treat _ and :
-    // as interchangeable so that functions shown as eligible in the UI are actually instrumented.
+    // team:my:service will see the rule filter displayed in the Datadog UI as team_my_service.
+    // The instrumenter must treat _ and : as interchangeable so that functions shown as
+    // eligible in the UI are actually instrumented.
+    // Note: AWS reserves the "aws:" tag prefix, so we use a custom colon-containing key here.
     const { FunctionName: functionName } = await createFunction({
-      Tags: { "aws:cloudformation:stack-name": "my-stack" },
+      Tags: { "team:my:service": "backend" },
     });
 
     await setRemoteConfig({
       ruleFilters: [
         {
-          key: "aws_cloudformation_stack-name",
-          values: ["my-stack"],
+          key: "team_my_service",
+          values: ["backend"],
           filter_type: "tag",
           allow: true,
         },

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -158,9 +158,6 @@ async function enrichFunctionsWithTags(
       {};
     for (const [key, value] of Object.entries(awsResourceTags)) {
       functionTags.push(key + ":" + value);
-      if (key.startsWith("aws:")) {
-        functionTags.push(key.replace(/:/g, "_") + ":" + value);
-      }
     }
 
     // Also add the runtime as a tag
@@ -181,6 +178,30 @@ async function enrichFunctionsWithTags(
   return enrichedFunctions;
 }
 export { enrichFunctionsWithTags };
+
+// REDAPL (Datadog's tag indexing backend) converts colons in tag keys to underscores,
+// since colon is used as the key:value separator. This means a rule filter created via
+// the Datadog UI for a tag like aws:cloudformation:stack-name will arrive here as
+// aws_cloudformation_stack-name. We cannot know which underscores were originally colons,
+// so we treat each underscore in the filter key as matching either _ or : in the actual tag.
+function functionTagMatchesFilter(
+  functionTags: Set<string>,
+  ruleFilterKey: string,
+  value: string,
+): boolean {
+  if (functionTags.has(ruleFilterKey + ":" + value)) {
+    return true;
+  }
+  if (!ruleFilterKey.includes("_")) {
+    return false;
+  }
+  const escapedKey = ruleFilterKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedValue = value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `^${escapedKey.replace(/_/g, "[_:]")}:${escapedValue}$`,
+  );
+  return Array.from(functionTags).some((tag) => pattern.test(tag));
+}
 
 export function satisfiesTargetingRules(
   functionName: string,
@@ -205,7 +226,7 @@ export function satisfiesTargetingRules(
       if (ruleFilter.allow) {
         let hasAllowedTag = false;
         for (const value of ruleFilterValues) {
-          if (functionTags.has(ruleFilterKey + ":" + value)) {
+          if (functionTagMatchesFilter(functionTags, ruleFilterKey, value)) {
             hasAllowedTag = true;
           }
         }
@@ -214,7 +235,7 @@ export function satisfiesTargetingRules(
         }
       } else {
         for (const value of ruleFilterValues) {
-          if (functionTags.has(ruleFilterKey + ":" + value)) {
+          if (functionTagMatchesFilter(functionTags, ruleFilterKey, value)) {
             return false;
           }
         }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -158,9 +158,8 @@ async function enrichFunctionsWithTags(
       {};
     for (const [key, value] of Object.entries(awsResourceTags)) {
       functionTags.push(key + ":" + value);
-      const normalizedKey = key.replace(/:/g, "_");
-      if (normalizedKey !== key) {
-        functionTags.push(normalizedKey + ":" + value);
+      if (key.startsWith("aws:")) {
+        functionTags.push(key.replace(/:/g, "_") + ":" + value);
       }
     }
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -158,6 +158,10 @@ async function enrichFunctionsWithTags(
       {};
     for (const [key, value] of Object.entries(awsResourceTags)) {
       functionTags.push(key + ":" + value);
+      const normalizedKey = key.replace(/:/g, "_");
+      if (normalizedKey !== key) {
+        functionTags.push(normalizedKey + ":" + value);
+      }
     }
 
     // Also add the runtime as a tag

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -1681,6 +1681,36 @@ describe("enrichFunctionsWithTags", () => {
     );
   });
 
+  test("should store AWS resource tags with colons in key in both raw and REDAPL-normalized form", async () => {
+    // REDAPL converts colons in tag keys to underscores, so the Datadog UI shows
+    // aws:cloudformation:stack-name as aws_cloudformation_stack-name.
+    // The instrumenter must match rule filters expressed in either form.
+    const functions = [
+      createTestLambdaFunction({
+        functionName: "functionA",
+        functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
+        runtime: "nodejs14.x",
+        tags: { "aws:cloudformation:stack-name": "my-stack" },
+        layers: [],
+        envVars: {},
+      }),
+    ];
+
+    const enrichedFunctions = await enrichFunctionsWithTags(
+      mockClient,
+      functions,
+    );
+
+    // Raw AWS form (for filters using the original tag key)
+    expect(enrichedFunctions[0].Tags).toContain(
+      "aws:cloudformation:stack-name:my-stack",
+    );
+    // REDAPL-normalized form (for filters as shown in the Datadog UI)
+    expect(enrichedFunctions[0].Tags).toContain(
+      "aws_cloudformation_stack-name:my-stack",
+    );
+  });
+
   test("should handle AWS resource tags with empty object", async () => {
     const functions = [
       createTestLambdaFunction({

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -1681,16 +1681,21 @@ describe("enrichFunctionsWithTags", () => {
     );
   });
 
-  test("should store AWS resource tags with colons in key in both raw and REDAPL-normalized form", async () => {
+  test("should store aws:-prefixed tags in both raw and REDAPL-normalized form", async () => {
     // REDAPL converts colons in tag keys to underscores, so the Datadog UI shows
     // aws:cloudformation:stack-name as aws_cloudformation_stack-name.
     // The instrumenter must match rule filters expressed in either form.
+    // Only aws:-prefixed keys get this treatment to avoid false positives between
+    // unrelated user tags like foo:bar and foo_bar.
     const functions = [
       createTestLambdaFunction({
         functionName: "functionA",
         functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
         runtime: "nodejs14.x",
-        tags: { "aws:cloudformation:stack-name": "my-stack" },
+        tags: {
+          "aws:cloudformation:stack-name": "my-stack",
+          "foo:bar": "baz",
+        },
         layers: [],
         envVars: {},
       }),
@@ -1709,6 +1714,9 @@ describe("enrichFunctionsWithTags", () => {
     expect(enrichedFunctions[0].Tags).toContain(
       "aws_cloudformation_stack-name:my-stack",
     );
+    // Non-aws: tags with colons should NOT be duplicated in normalized form
+    expect(enrichedFunctions[0].Tags).toContain("foo:bar:baz");
+    expect(enrichedFunctions[0].Tags).not.toContain("foo_bar:baz");
   });
 
   test("should handle AWS resource tags with empty object", async () => {

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -1776,7 +1776,6 @@ describe("enrichFunctionsWithTags", () => {
     );
   });
 
-
   test("should handle AWS resource tags with empty object", async () => {
     const functions = [
       createTestLambdaFunction({

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -180,6 +180,101 @@ describe("satisfiesTargetingRules", () => {
     });
   });
 
+  describe("When the filter key contains underscores that may represent colons (REDAPL normalization)", () => {
+    // REDAPL converts colons in tag keys to underscores, so a filter created via the
+    // Datadog UI for aws:cloudformation:stack-name arrives as aws_cloudformation_stack-name.
+    // Each underscore in the filter key should match either _ or : in the actual tag.
+    test("should match a tag whose key uses colons where the filter uses underscores", () => {
+      expect(
+        satisfiesTargetingRules(
+          "functionA",
+          new Set(["aws:cloudformation:stack-name:my-stack"]),
+          [
+            {
+              key: "aws_cloudformation_stack-name",
+              values: ["my-stack"],
+              allow: true,
+              filterType: "tag",
+            },
+          ],
+        ),
+      ).toBe(true);
+    });
+    test("should match a tag whose key uses a mix of colons and underscores", () => {
+      expect(
+        satisfiesTargetingRules(
+          "functionA",
+          new Set(["aws_cloudformation:stack-name:my-stack"]),
+          [
+            {
+              key: "aws_cloudformation_stack-name",
+              values: ["my-stack"],
+              allow: true,
+              filterType: "tag",
+            },
+          ],
+        ),
+      ).toBe(true);
+    });
+    test("should still match when the tag key already uses underscores", () => {
+      expect(
+        satisfiesTargetingRules(
+          "functionA",
+          new Set(["aws_cloudformation_stack-name:my-stack"]),
+          [
+            {
+              key: "aws_cloudformation_stack-name",
+              values: ["my-stack"],
+              allow: true,
+              filterType: "tag",
+            },
+          ],
+        ),
+      ).toBe(true);
+    });
+    test("should not match a tag with a different value", () => {
+      expect(
+        satisfiesTargetingRules(
+          "functionA",
+          new Set(["aws:cloudformation:stack-name:other-stack"]),
+          [
+            {
+              key: "aws_cloudformation_stack-name",
+              values: ["my-stack"],
+              allow: true,
+              filterType: "tag",
+            },
+          ],
+        ),
+      ).toBe(false);
+    });
+    test("should apply deny filter when tag key uses colons", () => {
+      expect(
+        satisfiesTargetingRules(
+          "functionA",
+          new Set([
+            "aws:cloudformation:stack-name:my-stack",
+            "runtime:nodejs18.x",
+          ]),
+          [
+            {
+              key: "runtime",
+              values: ["nodejs18.x"],
+              allow: true,
+              filterType: "tag",
+            },
+            {
+              key: "aws_cloudformation_stack-name",
+              values: ["my-stack"],
+              allow: false,
+              filterType: "tag",
+            },
+          ],
+        ),
+      ).toBe(false);
+    });
+  });
+
   describe("When the filter is a function-name-based allow filter", () => {
     test("should return true if the function name is allowed", () => {
       expect(
@@ -1681,43 +1776,6 @@ describe("enrichFunctionsWithTags", () => {
     );
   });
 
-  test("should store aws:-prefixed tags in both raw and REDAPL-normalized form", async () => {
-    // REDAPL converts colons in tag keys to underscores, so the Datadog UI shows
-    // aws:cloudformation:stack-name as aws_cloudformation_stack-name.
-    // The instrumenter must match rule filters expressed in either form.
-    // Only aws:-prefixed keys get this treatment to avoid false positives between
-    // unrelated user tags like foo:bar and foo_bar.
-    const functions = [
-      createTestLambdaFunction({
-        functionName: "functionA",
-        functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
-        runtime: "nodejs14.x",
-        tags: {
-          "aws:cloudformation:stack-name": "my-stack",
-          "foo:bar": "baz",
-        },
-        layers: [],
-        envVars: {},
-      }),
-    ];
-
-    const enrichedFunctions = await enrichFunctionsWithTags(
-      mockClient,
-      functions,
-    );
-
-    // Raw AWS form (for filters using the original tag key)
-    expect(enrichedFunctions[0].Tags).toContain(
-      "aws:cloudformation:stack-name:my-stack",
-    );
-    // REDAPL-normalized form (for filters as shown in the Datadog UI)
-    expect(enrichedFunctions[0].Tags).toContain(
-      "aws_cloudformation_stack-name:my-stack",
-    );
-    // Non-aws: tags with colons should NOT be duplicated in normalized form
-    expect(enrichedFunctions[0].Tags).toContain("foo:bar:baz");
-    expect(enrichedFunctions[0].Tags).not.toContain("foo_bar:baz");
-  });
 
   test("should handle AWS resource tags with empty object", async () => {
     const functions = [


### PR DESCRIPTION
### What does this PR do?
In `enrichFunctionsWithTags`, when an AWS resource tag key contains colons, we now store both forms in the function's tag set:                  
  - Raw AWS form: `aws:cloudformation:stack-name:my-stack `                                                                                       
  - REDAPL-normalized form: `aws_cloudformation_stack-name:my-stack`                                                                              
This makes : and _ interchangeable during targeting rule evaluation. Tags without colons in their key are unaffected.                         

### Motivation

The Datadog UI queries REDAPL for Lambda tags, and REDAPL converts : in tag keys to `_` (since `:` is used as the key:value separator). This means a Lambda tagged by AWS as `aws:cloudformation:stack-name=my-stack` appears in the UI as `aws_cloudformation_stack-name`.                         
                                                                                                                                                
When a customer creates a remote instrumentation rule filter targeting `aws_cloudformation_stack-name`, that filter key is stored in the `_` form. But the instrumenter running in the customer's account sees the original AWS tag key with `:`, so `satisfiesTargetingRules` looks for  `aws_cloudformation_stack-name:my-stack` and finds nothing causing all matching functions to be skipped as not satisfying targeting rules.  

Also a [fix for this support ticket ](https://datadoghq.atlassian.net/browse/SLES-2894.P)

### Testing Guidelines

Unit tests were added

### Additional Notes

<!--- Anything else we should know when reviewing? --->
