### PR TITLE
Release v2.5.0

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -5,7 +5,7 @@ Description: Datadog Lambda Remote Instrumentation App
 Mappings:
   Constants:
     DdRemoteInstrumentApp:
-      Version: 2.4.0
+      Version: 2.5.0
     DdRemoteInstrumentLayerAwsAccount:
       Number: 464622532012
     InstrumenterFunctionName:


### PR DESCRIPTION
This release includes the following commits:
f9d82a7 update tests
7305b83 Added functionTagMatchesFilter helper before satisfiesTargetingRules f18445f add aws gaurd for tag
c64d2bb store raw AWS : tags
1bd3e66 chore: regenerate lockfiles after rebase
64fd602 ADMS: vuln patch: brace-expansion, diff
af94627 Add EventBridge delay and lambda processing latency metrics b420d0b Address PR feedback on instrumentation latency metric daa7ea3 Apply prettier formatting
ec2aa88 Rename SendDebugInformation mapping and remove time from manual invocations 9fdc725 Rename DD_SEND_DEBUG_INFORMATION to DD_INTERNAL_SEND_DEBUG_INFORMATION bf8d04d Add instrumentation latency metric and load tests

This release contains a fix to treat both `:` and `_` in tag keys as in line with how the Datadog UI treats those keys.