### PR TITLE
Clear config hash on CloudFormation stack update

### DIFF
--- a/integration-tests/cloudformation-events.test.ts
+++ b/integration-tests/cloudformation-events.test.ts
@@ -19,7 +19,11 @@ import {
   clearRemoteConfigs,
 } from "./utilities/remote-config";
 import { sleep } from "./utilities/sleep";
-import { doesObjectExist, deleteObject } from "./utilities/s3-helpers";
+import {
+  doesObjectExist,
+  deleteObject,
+  putObject,
+} from "./utilities/s3-helpers";
 import {
   createFunction,
   deleteTestFunctions,
@@ -27,7 +31,10 @@ import {
 import {
   invokeLambdaWithCFNCreateEvent,
   invokeLambdaWithCFNDeleteEvent,
+  invokeLambdaWithCFNUpdateEvent,
 } from "./utilities/remote-instrumenter-invocations";
+
+const CONFIG_HASH_KEY = "datadog_remote_instrumentation_config.txt";
 
 describe("Remote instrumenter cloudformation event tests", () => {
   let keysToDelete: string[] = [];
@@ -97,5 +104,24 @@ describe("Remote instrumenter cloudformation event tests", () => {
     // And instruments the lambda
     const isInstrumented = await isFunctionInstrumented(functionName);
     expect(isInstrumented).toStrictEqual(true);
+  });
+
+  it("deletes the config hash on stack update", async () => {
+    // Given a config hash already exists in S3
+    await putObject(CONFIG_HASH_KEY, "some-stale-config-hash");
+    expect(await doesObjectExist(CONFIG_HASH_KEY)).toStrictEqual(true);
+
+    // The remote instrumenter being called like it would be on stack update
+    const { s3Key } = await invokeLambdaWithCFNUpdateEvent();
+    keysToDelete.push(s3Key);
+
+    // Responds to CloudFormation so the custom resource update completes
+    const didCfnCallbackHappen = await doesObjectExist(s3Key);
+    expect(didCfnCallbackHappen).toEqual(true);
+
+    // And the config hash has been deleted so the next scheduled invocation
+    // re-evaluates instrumentation
+    const configHashStillExists = await doesObjectExist(CONFIG_HASH_KEY);
+    expect(configHashStillExists).toStrictEqual(false);
   });
 });

--- a/integration-tests/utilities/remote-config.ts
+++ b/integration-tests/utilities/remote-config.ts
@@ -12,10 +12,9 @@ const getRemoteConfig = async (): Promise<RemoteConfigData> => {
   const [apiKey, appKey] = await Promise.all([getApiKey(), getAppKey()]);
 
   const url =
-    "https://{DD_SITE}/api/v2/remote_config/products/serverless_remote_instrumentation/config?filter%5Baws_account_id%5D={AWS_ACCOUNT_SLOT}&filter%5Bregion%5D={REGION_SLOT}"
+    "https://{DD_SITE}/api/v2/remote_config/products/serverless_remote_instrumentation/config?filter%5Baws_account_id%5D={AWS_ACCOUNT_SLOT}"
       .replace("{DD_SITE}", ddSite)
-      .replace("{AWS_ACCOUNT_SLOT}", account)
-      .replace("{REGION_SLOT}", region);
+      .replace("{AWS_ACCOUNT_SLOT}", account);
 
   const response = await fetch(url, {
     headers: {

--- a/integration-tests/utilities/remote-instrumenter-invocations.ts
+++ b/integration-tests/utilities/remote-instrumenter-invocations.ts
@@ -101,9 +101,15 @@ const invokeLambdaWithCFNCreateEvent =
     return invokeLambdaWithCFNEvent("Create");
   };
 
+const invokeLambdaWithCFNUpdateEvent =
+  async (): Promise<InvokeLambdaWithCFNEventResult> => {
+    return invokeLambdaWithCFNEvent("Update");
+  };
+
 export {
   invokeLambdaWithScheduledEvent,
   invokeLambdaWithLambdaManagementEvent,
   invokeLambdaWithCFNDeleteEvent,
   invokeLambdaWithCFNCreateEvent,
+  invokeLambdaWithCFNUpdateEvent,
 };

--- a/integration-tests/utilities/s3-helpers.ts
+++ b/integration-tests/utilities/s3-helpers.ts
@@ -41,4 +41,15 @@ const deleteObject = async (key: string): Promise<any> => {
   return s3.send(command);
 };
 
-export { createPresignedUrl, doesObjectExist, deleteObject };
+const putObject = async (key: string, body: string): Promise<any> => {
+  const s3 = await getS3Client();
+  const command = new PutObjectCommand({
+    Bucket: bucketName,
+    Key: key,
+    Body: body,
+  });
+
+  return s3.send(command);
+};
+
+export { createPresignedUrl, doesObjectExist, deleteObject, putObject };

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -14,6 +14,7 @@ import {
   isLambdaManagementEvent,
   isStackDeletedEvent,
   isStackCreatedEvent,
+  isStackUpdatedEvent,
   isScheduledInvocationEvent,
   getFunctionFromLambdaEvent,
   selectEventFieldsForLogging,
@@ -125,6 +126,17 @@ export const handler = async (
     } else {
       await cfnResponse.send(event, context, "SUCCESS");
     }
+  } else if (isStackUpdatedEvent(event)) {
+    // On a stack update, delete the config hash so the next scheduled
+    // invocation treats the config as changed and re-instruments all functions.
+    logger.log(`Received a CloudFormation '${event.RequestType}' event.`);
+    try {
+      await deleteConfigHash(s3Client);
+    } catch (e) {
+      logger.error(e instanceof Error ? e.message : String(e));
+    }
+    // Always respond to CloudFormation so the custom resource update completes.
+    await cfnResponse.send(event, context, "SUCCESS");
   }
 
   // Else if it's a Lambda Management event, validate the event and instrument the function

--- a/src/lambda-event.ts
+++ b/src/lambda-event.ts
@@ -83,6 +83,17 @@ export function isStackCreatedEvent(
   );
 }
 
+export function isStackUpdatedEvent(
+  event: unknown,
+): event is CloudFormationEvent {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "RequestType" in event &&
+    (event as CloudFormationEvent).RequestType === "Update"
+  );
+}
+
 export function isLambdaManagementEvent(
   event: unknown,
 ): event is LambdaManagementEvent {

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -381,6 +381,64 @@ describe("stack delete events", () => {
   });
 });
 
+describe("stack update events", () => {
+  const event = {
+    RequestType: "Update",
+    ResponseURL: "url",
+    ResourceType: "AWS::CloudFormation::CustomResource",
+    StackId: "fakeStackId",
+    PhysicalResourceId: "fakePhysicalResourceId",
+    RequestId: "fakeRequestId",
+  };
+  const context = "context";
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("deletes the config hash and calls back with success", async () => {
+    mockedLambdaEvent.isStackUpdatedEvent.mockReturnValue(true);
+    mockedConfig.deleteConfigHash.mockResolvedValue(true);
+    mockedCfnResponse.send.mockResolvedValue(true);
+
+    await handler.handler(
+      event as unknown as InstrumenterEvent,
+      context as unknown as Context,
+    );
+
+    expect(mockedConfig.deleteConfigHash).toHaveBeenCalledTimes(1);
+    // It should not instrument or uninstrument any functions on an update.
+    expect(mockedInstrument.instrumentFunctions).not.toHaveBeenCalled();
+    expect(mockedCfnResponse.send).toHaveBeenCalledTimes(1);
+    expect(mockedCfnResponse.send).toHaveBeenCalledWith(
+      event,
+      context,
+      "SUCCESS",
+    );
+  });
+
+  test("still sends SUCCESS when deleting the config hash throws", async () => {
+    mockedLambdaEvent.isStackUpdatedEvent.mockReturnValue(true);
+    mockedConfig.deleteConfigHash.mockImplementation(() => {
+      throw new Error("delete failed");
+    });
+    mockedCfnResponse.send.mockResolvedValue(true);
+
+    await handler.handler(
+      event as unknown as InstrumenterEvent,
+      context as unknown as Context,
+    );
+
+    expect(mockedConfig.deleteConfigHash).toHaveBeenCalledTimes(1);
+    expect(mockedCfnResponse.send).toHaveBeenCalledTimes(1);
+    expect(mockedCfnResponse.send).toHaveBeenCalledWith(
+      event,
+      context,
+      "SUCCESS",
+    );
+  });
+});
+
 describe("stack create events", () => {
   beforeEach(() => {
     vi.resetAllMocks();

--- a/test/lambda-event.test.ts
+++ b/test/lambda-event.test.ts
@@ -4,6 +4,7 @@ import {
   isScheduledInvocationEvent,
   isStackDeletedEvent,
   isStackCreatedEvent,
+  isStackUpdatedEvent,
   isLambdaManagementEvent,
   isUpdateConfigurationEvent,
   isCreateFunctionEvent,
@@ -69,6 +70,25 @@ describe("isStackCreatedEvent", () => {
   it("should return false if the RequestType property is unset", () => {
     const event = {};
     expect(isStackCreatedEvent(event)).toBe(false);
+  });
+});
+
+describe("isStackUpdatedEvent", () => {
+  it("should return true if the event is a stack updated event", () => {
+    const event = {
+      RequestType: "Update",
+    };
+    expect(isStackUpdatedEvent(event)).toBe(true);
+  });
+  it("should return false if the event is not a stack updated event", () => {
+    const event = {
+      RequestType: "Not a stack updated event",
+    };
+    expect(isStackUpdatedEvent(event)).toBe(false);
+  });
+  it("should return false if the RequestType property is unset", () => {
+    const event = {};
+    expect(isStackUpdatedEvent(event)).toBe(false);
   });
 });
 


### PR DESCRIPTION
On a CloudFormation stack update clear the config hash from S3, forcing the next scheduled invocation to treat the config as changed and re-evaluate if functions should be updated.  This is a followup from a customer call where we implemented a bug fix and the customer updated their stack to include it, but then had to change the instrumentation rule for the instrumenter to try again.

Also removed the region filter on the get remote configs query for the integration tests.  This is because we 409 on any remote config in an aws account, so including the region means that we don't clear it first.

