### PR TITLE
Filter unactionable lambda events at the EventBridge rule

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -315,6 +315,22 @@ Resources:
         detail:
           eventSource:
             - lambda.amazonaws.com
+          # Only process events that the instrumenter will actually act on
+          eventName:
+            - UpdateFunctionConfiguration20150331v2
+            - CreateFunction20150331
+            - TagResource20170331v2
+            - UntagResource20170331v2
+          # Drop operations that failed
+          errorCode:
+            - exists: false
+          # Drop events from the instrumenter itself
+          userIdentity:
+            principalId:
+              - anything-but:
+                  wildcard: !Sub
+                    - "*${Name}*"
+                    - Name: !FindInMap [ Constants, InstrumenterFunctionName, Name ]
       State: "ENABLED"
       Targets:
         - Arn: !GetAtt LambdaFunction.Arn


### PR DESCRIPTION
## What

The `LambdaEventRule` forwarded every non-read-only Lambda management event (`source: aws.lambda`, `detail.eventSource: lambda.amazonaws.com`). The handler's `shouldSkipEvent` then discarded most of them *after* the function was already invoked.

This pushes those skip conditions up into the EventBridge `EventPattern` so the function is never invoked for events it would ignore.

## Changes (`template.yaml` only)
Added to the `LambdaEventRule` EventPattern:

- **`eventName` allowlist** — only the four events the handler acts on: `UpdateFunctionConfiguration20150331v2`, `CreateFunction20150331`, `TagResource20170331v2`, `UntagResource20170331v2`.
- **`errorCode: exists: false`** — drops operations that failed (nothing to instrument).
- **`userIdentity.principalId: anything-but wildcard`** — drops the instrumenter's own events, breaking the instrument → CloudTrail event → re-invoke feedback loop. The instrumenter assumes its execution role with a session name equal to its function name, so its `principalId` contains that name (matches the existing handler logic).

The handler's `shouldSkipEvent` is intentionally left in place as defense-in-depth — CloudTrail payload shapes vary and the code does semantic checks a pattern can't express (e.g. ignoring tag events that only touch the instrumenter's own version tag).

## Test plan
All integration tests still pass.  I ran the integration tests before and after deploying this change.  You can [see on the graph here](https://dd.datad0g.com/serverless/aws/lambda?search=functionname%3Aremote-instrumenter-testing-alexangelillo&fromUser=false&fullscreen_end_ts=1781703360000&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_start_ts=1781701387687&panel_end=1781703360000&panel_paused=true&panel_start=1781699760000&refresh_mode=sliding&sp=%5B%7B%22p%22%3A%7B%22entityId%22%3A%22aws-lambda-functions%2Bremote-instrumenter-testing-alexangelillo%2Beu-north-1%2B425362996713%22%7D%2C%22i%22%3A%22lambda-panel%22%7D%5D&start=1781699940000&end=1781703540000&paused=false)

<img width="1439" height="237" alt="image" src="https://github.com/user-attachments/assets/f82f536a-c6a0-4a8d-aabf-ab2e81bb1980" />
 The part between the first and second red vertical lines are the first run and the second run is to the right of the second red annotation.  In the first run there were 652 invocations compared to 88 with this change.  I also saw an ~30 second decrease in integration test run time, corresponding to ~50ms per invocation (652-88=564 fewer invocations, divided over 30 seconds) which sounds about right.


[Comparing the time to instrument for each run](https://dd.datad0g.com/metric/explorer?fromUser=false&graph_layout=stacked&start=1781700627296&end=1781704227296&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMjJCBhQODAAdEaqOAhwTqIaBXjqIh3aTZiqAEbJTh6R8P0ITnAVcANN3b2znpIiTpgdIplYwABUPCB8oJHRubFYAEyJtanpeFk5eYiFxSDX5VU1KQ3NVrtTqrbR9JaDYZRcapKYYGYQ+aLZYLCGjXSwToCTAHY6nCjnKKva4AZnuKTSGWyynyH0S31ylWqDwBLTgbQ6XREPTBsx0ULGEzhCIGSIhAphTnk2hw2Q0GlEMG2niW+yOJx4AF0qK53HhMKFwrrVPqMDFSvF8aBjabzTpblaQDbMHa4mStVQelg0DlQPIMD6EB1lACnJkDQrMok3AJtE5RjRchUA2ZPjGdE4jIttFoUIIA1oqGhRJ05IplOli1BEsWRJ16ExlCI3B40PikhB7DinGXXrWlFqeHwQF3xABhKTCGAoET6tA8IA), there was an ~10% decrease in the peak but the shapes of the graphs are pretty different so not sure if we can say anything too conclusively about this.

I only ran the tests once to compare them so take the exact numbers with a grain of salt, but that there is a change I think is clear enough.