### PR TITLE
Reduce instrumenter duration by parallelizing per-function work

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -138,37 +138,56 @@ export async function getLambdaFunction(
   return getFunctionCommandOutput;
 }
 
+// Collect a single function's tags (from its env DD_TAGS, its AWS resource
+// tags, and its runtime) into the enriched shape used downstream.
+async function enrichFunctionWithTags(
+  client: LambdaClient,
+  lambdaFunc: UnenrichedLambdaFunction,
+): Promise<LambdaFunction> {
+  const functionTagArray =
+    lambdaFunc.Environment?.Variables?.DD_TAGS?.split(" ") || [];
+  let functionTags = functionTagArray.map((functionTag) =>
+    functionTag?.replace(/"/g, ""),
+  );
+
+  // Tags may be a Record<string, string> from the AWS SDK's GetFunctionCommandOutput
+  const awsResourceTags: Record<string, string> =
+    lambdaFunc.Tags ??
+    (await getAWSResourceTagsForFunction(client, lambdaFunc.FunctionName!)) ??
+    {};
+  for (const [key, value] of Object.entries(awsResourceTags)) {
+    functionTags.push(key + ":" + value);
+  }
+
+  // Also add the runtime as a tag
+  functionTags.push("runtime:" + lambdaFunc.Runtime);
+
+  const functionTagsSet = new Set(functionTags);
+  return {
+    ...lambdaFunc,
+    FunctionName: lambdaFunc.FunctionName!,
+    Tags: functionTagsSet,
+  };
+}
+
+// The number of functions to enrich concurrently. Each function whose tags
+// aren't already present requires a GetFunction call, so we bound concurrency
+// to avoid throttling the Lambda API on accounts with many functions.
+const ENRICH_CONCURRENCY = 50;
+
 async function enrichFunctionsWithTags(
   client: LambdaClient,
   functions: UnenrichedLambdaFunction[],
 ): Promise<LambdaFunction[]> {
-  // Loop through the functions and collect each one's tags
+  // Enrich functions in bounded-concurrency batches, fetching missing tags in
+  // parallel within each batch.
   const enrichedFunctions: LambdaFunction[] = [];
-  for (const lambdaFunc of functions) {
-    const functionTagArray =
-      lambdaFunc.Environment?.Variables?.DD_TAGS?.split(" ") || [];
-    let functionTags = functionTagArray.map((functionTag) =>
-      functionTag?.replace(/"/g, ""),
+  for (let i = 0; i < functions.length; i += ENRICH_CONCURRENCY) {
+    const batch = functions.slice(i, i + ENRICH_CONCURRENCY);
+    const enrichedBatch = await Promise.all(
+      batch.map((lambdaFunc) => enrichFunctionWithTags(client, lambdaFunc)),
     );
-
-    // Tags may be a Record<string, string> from the AWS SDK's GetFunctionCommandOutput
-    const awsResourceTags: Record<string, string> =
-      lambdaFunc.Tags ??
-      (await getAWSResourceTagsForFunction(client, lambdaFunc.FunctionName!)) ??
-      {};
-    for (const [key, value] of Object.entries(awsResourceTags)) {
-      functionTags.push(key + ":" + value);
-    }
-
-    // Also add the runtime as a tag
-    functionTags.push("runtime:" + lambdaFunc.Runtime);
-
-    const functionTagsSet = new Set(functionTags);
-    enrichedFunctions.push({
-      ...lambdaFunc,
-      FunctionName: lambdaFunc.FunctionName!,
-      Tags: functionTagsSet,
-    });
+    enrichedFunctions.push(...enrichedBatch);
   }
   logger.log(
     `Enriched the following functions with tags: '${JSON.stringify(

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -110,8 +110,6 @@ export async function instrumentWithDatadogCi(
   const operationName = instrument ? INSTRUMENT : UNINSTRUMENT;
   const operation = instrument ? "instrument" : "uninstrument";
 
-  await waitUntilFunctionIsActive(functionName);
-
   logger.logInstrumentOutcome({
     ddSlsEventName: operationName,
     outcome: IN_PROGRESS,
@@ -128,6 +126,12 @@ export async function instrumentWithDatadogCi(
   let reason, reasonCode;
 
   try {
+    // Wait inside the try so that a failure here (e.g. a throttle or
+    // ResourceNotFound from the GetFunctionConfiguration poll) is recorded as a
+    // per-function FAILED outcome rather than rejecting the surrounding
+    // Promise.all and taking down the rest of the batch.
+    await waitUntilFunctionIsActive(functionName);
+
     let functionConfig: DatadogCiFunctionConfiguration;
 
     if (instrument) {

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -257,18 +257,22 @@ export async function instrumentFunctions(
         functionsToTagInBatch.map((f) => f.FunctionArn!),
       );
 
-      // Then, instrument all functions in this batch that need instrumentation
+      // Then, instrument all functions in this batch that need instrumentation.
+      // Functions within a batch are processed concurrently; the batch size
+      // bounds how many Lambda API calls are in flight at once.
       const functionsToInstrumentInBatch = batch.filter(
         (func) => func.needsInstrumentation,
       );
-      for (const functionToInstrument of functionsToInstrumentInBatch) {
-        await instrumentWithDatadogCi(
-          functionToInstrument,
-          true,
-          config,
-          instrumentOutcome,
-        );
-      }
+      await Promise.all(
+        functionsToInstrumentInBatch.map((functionToInstrument) =>
+          instrumentWithDatadogCi(
+            functionToInstrument,
+            true,
+            config,
+            instrumentOutcome,
+          ),
+        ),
+      );
     }
 
     const uninstrumentBatches = createFunctionBatches(
@@ -284,18 +288,21 @@ export async function instrumentFunctions(
         `Uninstrumenting batch ${i + 1}/${uninstrumentBatches.length} with ${batch.length} functions`,
       );
 
-      // First, uninstrument all functions in this batch that need uninstrumentation
+      // First, uninstrument all functions in this batch that need
+      // uninstrumentation. Functions within a batch are processed concurrently.
       const functionsToUninstrumentInBatch = batch.filter(
         (func) => func.needsUninstrumentation,
       );
-      for (const functionToUninstrument of functionsToUninstrumentInBatch) {
-        await instrumentWithDatadogCi(
-          functionToUninstrument,
-          false,
-          config,
-          instrumentOutcome,
-        );
-      }
+      await Promise.all(
+        functionsToUninstrumentInBatch.map((functionToUninstrument) =>
+          instrumentWithDatadogCi(
+            functionToUninstrument,
+            false,
+            config,
+            instrumentOutcome,
+          ),
+        ),
+      );
 
       // Then, untag all functions in this batch that need untagging (but only if uninstrumentation didn't fail)
       const functionsToUntagInBatch = batch.filter(

--- a/test/instrument.test.ts
+++ b/test/instrument.test.ts
@@ -41,6 +41,7 @@ vi.mock("@datadog/datadog-ci-plugin-lambda/functions/commons", () => ({
 import { getInstrumentedFunctionConfig } from "@datadog/datadog-ci-plugin-lambda/functions/instrument";
 import { getUninstrumentedFunctionConfig } from "@datadog/datadog-ci-plugin-lambda/functions/uninstrument";
 import { updateLambdaFunctionConfig } from "@datadog/datadog-ci-plugin-lambda/functions/commons";
+import { waitUntilFunctionIsActive } from "../src/functions";
 
 describe("getExtensionAndRuntimeLayerVersion", () => {
   it("should return the layer and runtime version for node", () => {
@@ -317,6 +318,48 @@ describe("instrumentFunctions", () => {
         reasonCode: "datadog-ci-error",
       },
     });
+  });
+
+  test("one function's waitUntilFunctionIsActive failure does not abort the batch", async () => {
+    const functionFoo2: LambdaFunction = {
+      FunctionName: "foo2",
+      FunctionArn: "arn:aws:lambda:us-east-2:123456789:function:foo2",
+      Runtime: "nodejs18.x",
+      Tags: new Set(["env:prod"]),
+    };
+    // Reject the active-wait for one function (e.g. a throttle/ResourceNotFound)
+    (waitUntilFunctionIsActive as any).mockImplementation((name: string) =>
+      name === functionFoo.FunctionName
+        ? Promise.reject(new Error("throttled"))
+        : Promise.resolve(),
+    );
+
+    const outcome = {
+      instrument: { succeeded: {} as any, failed: {} as any, skipped: {} },
+      uninstrument: { succeeded: {}, failed: {}, skipped: {} },
+    };
+
+    // The batch as a whole should not reject
+    await expect(
+      instrument.instrumentFunctions(
+        mockS3Client,
+        [rcConfig],
+        [functionFoo, functionFoo2],
+        outcome as any,
+        mockTaggingClient,
+        SCHEDULED_INVOCATION_EVENT,
+      ),
+    ).resolves.toBeUndefined();
+
+    // The failing function is recorded as FAILED, not thrown
+    expect(outcome.instrument.failed[functionFoo.FunctionName]).toEqual({
+      functionArn: functionFoo.FunctionArn,
+      reason: "throttled",
+      reasonCode: "datadog-ci-error",
+    });
+    // The other function in the batch is still instrumented
+    expect(outcome.instrument.succeeded["foo2"]).toBeDefined();
+    expect(updateLambdaFunctionConfig).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## What
Two serial loops dominated the instrumenter's wall-clock time on accounts with many functions. Both were work that was already designed to be batched but executed one call at a time. This parallelizes them.  This should still avoid throttles because we use the same AWS clients across the board and are using adaptive retry mode.

## Changes
**`src/functions.ts` — `enrichFunctionsWithTags`**
Previously called `GetFunction` for each function's tags **serially** (N × ~200-300ms). Extracted the per-function logic into `enrichFunctionWithTags` and run it in **bounded-concurrency batches of 50**, so missing tags are fetched in parallel. Bounded deliberately — firing thousands of `GetFunction` calls at once would risk throttling the Lambda API (and the retries would end up slower). Order is preserved.

**`src/instrument.ts` — `instrumentFunctions`**
The code splits functions into batches of 50, but then awaited each function's `instrumentWithDatadogCi` **serially within the batch** — so the batching bought nothing. Each call does `waitUntilFunctionIsActive` (up to 10×1s polls) + config fetch + `UpdateFunctionConfiguration`. Changed both the instrument and uninstrument inner loops to `Promise.all`; the batch size (50) now acts as the concurrency cap.

Safe under concurrency because `instrumentWithDatadogCi` records results keyed by function name (`instrumentOutcome[operation][outcome][functionName]`) and catches its own errors, so there's no shared-state race and one failure can't reject the batch.

## Test plan
Ran the integration tests before and after deploying this change.  Compare the max duration of the [first run](https://dd.datad0g.com/metric/explorer?graph_layout=stacked&start=1781701382211&end=1781702358867&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYAMwGIFCeGE4a+NoAxkrIIOoIulmWgWZxyh7EyBhgGgB0mKoARil1UHjanpIidZU+eKrAUFBOdpk5TgDWcFjV2iLVtciNLRjIcHgAtCJuTJtkyAAsAEwArPEAbMcAnNcXAOxk8ciCeCJZElLIRqo4CHCbUQaQoDOAif7aTb-YGiGCbDBoODEDAieBoCBoNA4HggHgAXSornceEwoXCRNUJIwMTKCVxBJAwKwiJkIHkCMQ-2UUBwMCcWVJGggWSSbgE2icTRoeQAbgizCUQGKdKM4DKdFoUIIEVoqOiRHAnHJFMoMuioEl9Yb6ExlDt3AjcfwIPZMFgjQpciArfSeHxGfJ0QgAMJSYQwFAiEloHhAA)

<img width="1318" height="302" alt="image" src="https://github.com/user-attachments/assets/f30b9d4e-02e8-43d5-9661-dcd9543dcb4a" />

Get the total time the lambda was running by using this query

```
dd-auth --domain dd.datad0g.com << 'EOF'
curl -s -X POST "https://api.${DD_SITE}/api/v2/query/scalar" \
  -H "DD-API-KEY: ${DD_API_KEY}" -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" -H "Content-Type: application/json" \
  -d "{\"data\":{\"type\":\"scalar_request\",\"attributes\":{\"from\":1781701382211,\"to\":1781702358867,\"formulas\":[{\"formula\":\"a\"}],\"queries\":[{\"name\":\"a\",\"data_source\":\"metrics\",\"aggregator\":\"sum\",\"query\":\"sum:aws.lambda.duration.sum{dd_resource_key:arn:aws:lambda:eu-north-1:425362996713:function:remote-instrumenter-testing-alexangelillo}\"}]}}}" | jq '.data.attributes.columns[0].values[0]'
EOF
```

Which returns `220555.49998975`


To the [second run](https://dd.datad0g.com/metric/explorer?graph_layout=stacked&start=1781701382211&end=1781702358867&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYAMwGIFCeGE4a+NoAxkrIIOoIulmWgWZxyh7EyBhgGgB0mKoARil1UHjanpIidZU+eKrAUFBOdpk5TgDWcFjV2iLVtciNLRjIcHgAtCJuTJtkyAAsAEwArPEAbMcAnNcXAOxk8ciCeCJZElLIRqo4CHCbUQaQoDOAif7aTb-YGiGCbDBoODEDAieBoCBoNA4HggHgAXSornceEwoXCRNUJIwMTKCVxBJAwKwiJkIHkCMQ-2UUBwMCcWVJGggWSSbgE2icTRoeQAbgizCUQGKdKM4DKdFoUIIEVoqOiRHAnHJFMoMuioEl9Yb6ExlDt3AjcfwIPZMFgjQpciArfSeHxGfJ0QgAMJSYQwFAiEloHhAA)

<img width="1318" height="302" alt="image" src="https://github.com/user-attachments/assets/cf047cdf-dd34-49dc-a3db-2ec95a8f2a2c" />

Get the total time the lambda was running by using this query

```
dd-auth --domain dd.datad0g.com << 'EOF'
curl -s -X POST "https://api.${DD_SITE}/api/v2/query/scalar" \
  -H "DD-API-KEY: ${DD_API_KEY}" -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" -H "Content-Type: application/json" \
  -d "{\"data\":{\"type\":\"scalar_request\",\"attributes\":{\"from\":1781705838116,\"to\":1781707499000,\"formulas\":[{\"formula\":\"a\"}],\"queries\":[{\"name\":\"a\",\"data_source\":\"metrics\",\"aggregator\":\"sum\",\"query\":\"sum:aws.lambda.duration.sum{dd_resource_key:arn:aws:lambda:eu-north-1:425362996713:function:remote-instrumenter-testing-alexangelillo}\"}]}}}" | jq '.data.attributes.columns[0].values[0]'
EOF
```

Which returns `204047.32998488002`.  Compared the first run there was an ~7.5% reduction in time that the lambda spent running.  This is over one test run so it is likely to be different, but this is an ~20 second difference over the course of an integration test run.  The time to instrument graph is fairly unchanged since this change affects doing multiple lambdas in parallel, which doesn't affect the lambda management events.