### PR TITLE
Avoid duplicate GetFunction on lambda management event path

### DIFF
--- a/src/lambda-event.ts
+++ b/src/lambda-event.ts
@@ -2,7 +2,10 @@ import { LambdaClient } from "@aws-sdk/client-lambda";
 import { ResourceNotFoundException } from "@aws-sdk/client-lambda";
 import { FunctionConfiguration } from "@aws-sdk/client-lambda";
 import { getLambdaFunction } from "./functions";
-import { DD_SLS_REMOTE_INSTRUMENTER_VERSION } from "./consts";
+import {
+  DD_SLS_REMOTE_INSTRUMENTER_VERSION,
+  type UnenrichedLambdaFunction,
+} from "./consts";
 import { logger } from "./logger";
 
 const UPDATE_FUNCTION_CONFIGURATION_EVENT_NAME =
@@ -179,7 +182,7 @@ export { shouldSkipEvent };
 export async function getFunctionFromLambdaEvent(
   lambdaClient: LambdaClient,
   event: LambdaManagementEvent,
-): Promise<FunctionConfiguration | undefined> {
+): Promise<UnenrichedLambdaFunction | undefined> {
   // If it's not a supported event type, skip it
   if (shouldSkipEvent(event)) {
     return;
@@ -217,7 +220,14 @@ export async function getFunctionFromLambdaEvent(
       lambdaClient,
       functionName!,
     );
-    return functionFromEvent.Configuration;
+    // getLambdaFunction (GetFunction) already returns the resource tags, so
+    // thread them through here. Defaulting to {} (rather than leaving it
+    // undefined) ensures enrichFunctionsWithTags uses these tags instead of
+    // issuing a second GetFunction call for the same function.
+    return {
+      ...functionFromEvent.Configuration,
+      Tags: functionFromEvent.Tags ?? {},
+    };
   } catch (e) {
     if (e instanceof ResourceNotFoundException) {
       return;

--- a/test/lambda-event.test.ts
+++ b/test/lambda-event.test.ts
@@ -369,10 +369,7 @@ describe("getFunctionFromLambdaEvent", () => {
       Tags: { env: "prod" },
     } as any);
 
-    const result = await getFunctionFromLambdaEvent(
-      {} as any,
-      updateEvent,
-    );
+    const result = await getFunctionFromLambdaEvent({} as any, updateEvent);
 
     expect(result).toEqual({
       FunctionName: "my-func",
@@ -389,10 +386,7 @@ describe("getFunctionFromLambdaEvent", () => {
       Tags: undefined,
     } as any);
 
-    const result = await getFunctionFromLambdaEvent(
-      {} as any,
-      updateEvent,
-    );
+    const result = await getFunctionFromLambdaEvent({} as any, updateEvent);
 
     expect(result?.Tags).toEqual({});
   });

--- a/test/lambda-event.test.ts
+++ b/test/lambda-event.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../src/functions", async () => ({
+  ...(await vi.importActual("../src/functions")),
+  getLambdaFunction: vi.fn(),
+}));
 
 import {
   isScheduledInvocationEvent,
@@ -11,9 +16,11 @@ import {
   isUntagResourceEvent,
   shouldSkipEvent,
   selectEventFieldsForLogging,
+  getFunctionFromLambdaEvent,
   LambdaManagementEvent,
   InstrumenterEvent,
 } from "../src/lambda-event";
+import { getLambdaFunction } from "../src/functions";
 
 describe("isScheduledInvocationEvent", () => {
   it("should return true if the event is a scheduled invocation event", () => {
@@ -335,5 +342,58 @@ describe("selectEventFieldsForLogging", () => {
     expect(
       selectEventFieldsForLogging(event as unknown as InstrumenterEvent),
     ).toStrictEqual(expected);
+  });
+});
+
+describe("getFunctionFromLambdaEvent", () => {
+  const mockedGetLambdaFunction = vi.mocked(getLambdaFunction);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "instrumenter-function";
+  });
+
+  const updateEvent = {
+    "detail-type": "AWS API Call via CloudTrail",
+    source: "aws.lambda",
+    detail: {
+      eventName: "UpdateFunctionConfiguration20150331v2",
+      requestParameters: { functionName: "my-func" },
+      responseElements: { functionName: "my-func" },
+    },
+  } as unknown as LambdaManagementEvent;
+
+  it("returns the function config with the tags from the GetFunction call (no second fetch)", async () => {
+    mockedGetLambdaFunction.mockResolvedValue({
+      Configuration: { FunctionName: "my-func", Runtime: "nodejs18.x" },
+      Tags: { env: "prod" },
+    } as any);
+
+    const result = await getFunctionFromLambdaEvent(
+      {} as any,
+      updateEvent,
+    );
+
+    expect(result).toEqual({
+      FunctionName: "my-func",
+      Runtime: "nodejs18.x",
+      Tags: { env: "prod" },
+    });
+    // The resolver should fetch the function exactly once.
+    expect(mockedGetLambdaFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults Tags to an empty object when the function has none, so enrichment doesn't re-fetch", async () => {
+    mockedGetLambdaFunction.mockResolvedValue({
+      Configuration: { FunctionName: "my-func", Runtime: "nodejs18.x" },
+      Tags: undefined,
+    } as any);
+
+    const result = await getFunctionFromLambdaEvent(
+      {} as any,
+      updateEvent,
+    );
+
+    expect(result?.Tags).toEqual({});
   });
 });

--- a/test/lambda-event.test.ts
+++ b/test/lambda-event.test.ts
@@ -20,7 +20,7 @@ import {
   LambdaManagementEvent,
   InstrumenterEvent,
 } from "../src/lambda-event";
-import { getLambdaFunction } from "../src/functions";
+import { getLambdaFunction, enrichFunctionsWithTags } from "../src/functions";
 
 describe("isScheduledInvocationEvent", () => {
   it("should return true if the event is a scheduled invocation event", () => {
@@ -389,5 +389,25 @@ describe("getFunctionFromLambdaEvent", () => {
     const result = await getFunctionFromLambdaEvent({} as any, updateEvent);
 
     expect(result?.Tags).toEqual({});
+  });
+
+  it("end-to-end: resolving + enriching a lambda event makes exactly one GetFunction call", async () => {
+    // Real getFunctionFromLambdaEvent + real enrichFunctionsWithTags; only the
+    // GetFunction AWS SDK call is mocked. This proves the tags fetched while
+    // resolving the function are reused by enrichment instead of triggering a
+    // second GetFunction.
+    mockedGetLambdaFunction.mockResolvedValue({
+      Configuration: { FunctionName: "my-func", Runtime: "nodejs18.x" },
+      Tags: { env: "prod" },
+    } as any);
+
+    const fn = await getFunctionFromLambdaEvent({} as any, updateEvent);
+    const [enriched] = await enrichFunctionsWithTags({} as any, [fn!]);
+
+    // Exactly one GetFunction across resolve + enrich (was two before the fix).
+    expect(mockedGetLambdaFunction).toHaveBeenCalledTimes(1);
+    // Enrichment used the threaded tags (env:prod present alongside runtime).
+    expect(enriched.Tags?.has("env:prod")).toBe(true);
+    expect(enriched.Tags?.has("runtime:nodejs18.x")).toBe(true);
   });
 });


### PR DESCRIPTION
## What

On the Lambda management event path, the instrumenter made **two** `GetFunction` calls for the same function:

1. `getFunctionFromLambdaEvent` calls `GetFunction` (which returns the config **and** its tags) but returned only `.Configuration`, discarding the tags.
2. `enrichFunctionsWithTags`, seeing no `Tags` on that object, issued a **second** `GetFunction` to read them.

This threads the already-fetched tags through so the second call is eliminated — one fewer Lambda API round-trip on every lambda management event (the high-frequency, latency-sensitive path).

## Changes

- **`src/lambda-event.ts`** — `getFunctionFromLambdaEvent` now returns `{ ...Configuration, Tags: functionFromEvent.Tags ?? {} }` (typed as `UnenrichedLambdaFunction`). The `?? {}` matters: leaving `Tags` undefined would still trigger the re-fetch in `enrichFunctionsWithTags` (`lambdaFunc.Tags ?? getAWSResourceTagsForFunction(...)`).
- **`test/lambda-event.test.ts`** — added coverage for `getFunctionFromLambdaEvent` (previously untested): verifies it returns config + tags with a single fetch, and that a function with no tags defaults to `{}`.

## Test plan
All of the integration tests still pass. I ran this a few times to try to get metrics to more clearly show something, but honestly this made less of a difference than I thought it would.  Within a couple of runs the duration is either about the same or *maybe* 100ms better.  I think it still is clearly better to remove the call since we don't need it, but it hasn't made as much of a difference as I'd have hoped.


[Here is the distribution of latency from after the change](https://dd.datad0g.com/dashboard/ssx-f62-dtr?bits_chat_id=66674ab3-d8eb-4e10-bda1-f8c9a5c297f0&fromUser=false&refresh_mode=paused&from_ts=1781724300000&to_ts=1781725500000&live=false)

<img width="1036" height="322" alt="image" src="https://github.com/user-attachments/assets/36ba9b0a-61d5-4726-96c9-9e19f64cbc69" />


[Here is the distribution of duration from after the change](https://dd.datad0g.com/dashboard/ssx-f62-dtr?bits_chat_id=66674ab3-d8eb-4e10-bda1-f8c9a5c297f0&fromUser=false&refresh_mode=paused&from_ts=1781726280000&to_ts=1781727480000&live=false)

<img width="1036" height="322" alt="image" src="https://github.com/user-attachments/assets/a4d846e7-3bca-436b-908c-cf1bc421eed6" />

Maybe it looks more skewed left, but anytime I try to aggregate it into a single number the results don't really show anything significant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)