### PR TITLE
Use the AWS SDK waiter for waitUntilFunctionIsActive

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -596,27 +596,22 @@ export function needsInstrumentationUpdate(
   return { instrument: true, uninstrument: false, tag: true, untag: false };
 }
 
-// The maximum time, in seconds, to wait for a function to become Active before
-// giving up.
+// Max seconds to wait for a function to become Active before giving up.
 const FUNCTION_ACTIVE_MAX_WAIT_SECONDS = 10;
 
 export const waitUntilFunctionIsActive = async (
   functionName: string,
 ): Promise<boolean> => {
-  // Editing a function while it is in a pending state throws a resource
-  // conflict exception, so wait for it to become Active first.
-  // waitUntilFunctionActiveV2 polls the GetFunction API:
-  // https://github.com/aws/aws-sdk-js-v3/blob/main/clients/client-lambda/src/waiters/waitForFunctionActiveV2.ts
+  // Editing a function in a pending state throws a resource conflict, so wait
+  // for it to become Active. The waiter resolves on success and throws otherwise.
   const lambdaClient = getLambdaClient();
   try {
     await waitUntilFunctionActiveV2(
       { client: lambdaClient, maxWaitTime: FUNCTION_ACTIVE_MAX_WAIT_SECONDS },
       { FunctionName: functionName },
     );
-    // The waiter resolves only when the function reached the Active state.
     return true;
   } catch {
-    // waitUntil* throws on TIMEOUT/FAILURE; return false so callers can proceed.
     return false;
   }
 };

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -10,7 +10,6 @@ import {
   LambdaClient,
   waitUntilFunctionActiveV2,
 } from "@aws-sdk/client-lambda";
-import { WaiterState } from "@smithy/core/client";
 import type {
   FunctionConfiguration,
   GetFunctionCommandOutput,
@@ -610,11 +609,12 @@ export const waitUntilFunctionIsActive = async (
   // https://github.com/aws/aws-sdk-js-v3/blob/main/clients/client-lambda/src/waiters/waitForFunctionActiveV2.ts
   const lambdaClient = getLambdaClient();
   try {
-    const { state } = await waitUntilFunctionActiveV2(
+    await waitUntilFunctionActiveV2(
       { client: lambdaClient, maxWaitTime: FUNCTION_ACTIVE_MAX_WAIT_SECONDS },
       { FunctionName: functionName },
     );
-    return state === WaiterState.SUCCESS;
+    // The waiter resolves only when the function reached the Active state.
+    return true;
   } catch {
     // waitUntil* throws on TIMEOUT/FAILURE; return false so callers can proceed.
     return false;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -598,17 +598,15 @@ export function needsInstrumentationUpdate(
 }
 
 // The maximum time, in seconds, to wait for a function to become Active before
-// giving up. Roughly preserves the previous hand-rolled loop's ~10s ceiling.
+// giving up.
 const FUNCTION_ACTIVE_MAX_WAIT_SECONDS = 10;
 
 export const waitUntilFunctionIsActive = async (
   functionName: string,
 ): Promise<boolean> => {
-  // Attempting to edit a function that is in a pending state will cause a
-  // resource conflict exception to be thrown, and they usually exit that state
-  // after a few seconds. Use the AWS SDK's built-in waiter, which polls with
-  // exponential backoff and handles terminal states, instead of a hand-rolled
-  // polling loop. waitUntilFunctionActiveV2 polls the GetFunction API:
+  // Editing a function while it is in a pending state throws a resource
+  // conflict exception, so wait for it to become Active first.
+  // waitUntilFunctionActiveV2 polls the GetFunction API:
   // https://github.com/aws/aws-sdk-js-v3/blob/main/clients/client-lambda/src/waiters/waitForFunctionActiveV2.ts
   const lambdaClient = getLambdaClient();
   try {
@@ -618,8 +616,7 @@ export const waitUntilFunctionIsActive = async (
     );
     return state === WaiterState.SUCCESS;
   } catch {
-    // waitUntil* throws on TIMEOUT/FAILURE. Preserve the previous behavior of
-    // returning false (rather than throwing) so callers can still proceed.
+    // waitUntil* throws on TIMEOUT/FAILURE; return false so callers can proceed.
     return false;
   }
 };

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -3,14 +3,14 @@ import {
   GetResourcesCommand,
 } from "@aws-sdk/client-resource-groups-tagging-api";
 import type { GetResourcesCommandOutput } from "@aws-sdk/client-resource-groups-tagging-api";
-import { sleep } from "./sleep";
 import {
   GetFunctionCommand,
-  GetFunctionConfigurationCommand,
   ListFunctionsCommand,
   GetAccountSettingsCommand,
   LambdaClient,
+  waitUntilFunctionActiveV2,
 } from "@aws-sdk/client-lambda";
+import { WaiterState } from "@smithy/core/client";
 import type {
   FunctionConfiguration,
   GetFunctionCommandOutput,
@@ -597,30 +597,31 @@ export function needsInstrumentationUpdate(
   return { instrument: true, uninstrument: false, tag: true, untag: false };
 }
 
+// The maximum time, in seconds, to wait for a function to become Active before
+// giving up. Roughly preserves the previous hand-rolled loop's ~10s ceiling.
+const FUNCTION_ACTIVE_MAX_WAIT_SECONDS = 10;
+
 export const waitUntilFunctionIsActive = async (
   functionName: string,
 ): Promise<boolean> => {
-  // Attempting to edit a function that is in a pending state will cause
-  // a resource conflict exception to be thrown, and they usually exit that
-  // state after a few seconds
+  // Attempting to edit a function that is in a pending state will cause a
+  // resource conflict exception to be thrown, and they usually exit that state
+  // after a few seconds. Use the AWS SDK's built-in waiter, which polls with
+  // exponential backoff and handles terminal states, instead of a hand-rolled
+  // polling loop. waitUntilFunctionActiveV2 polls the GetFunction API:
+  // https://github.com/aws/aws-sdk-js-v3/blob/main/clients/client-lambda/src/waiters/waitForFunctionActiveV2.ts
   const lambdaClient = getLambdaClient();
-  let isFunctionReady = false;
-  let count = 0;
-  while (!isFunctionReady && count < 10) {
-    count += 1;
-    const functionStatus = await lambdaClient.send(
-      new GetFunctionConfigurationCommand({
-        FunctionName: functionName,
-      }),
+  try {
+    const { state } = await waitUntilFunctionActiveV2(
+      { client: lambdaClient, maxWaitTime: FUNCTION_ACTIVE_MAX_WAIT_SECONDS },
+      { FunctionName: functionName },
     );
-    const { State } = functionStatus;
-    if (State !== "Pending") {
-      isFunctionReady = true;
-    } else {
-      await sleep(1000);
-    }
+    return state === WaiterState.SUCCESS;
+  } catch {
+    // waitUntil* throws on TIMEOUT/FAILURE. Preserve the previous behavior of
+    // returning false (rather than throwing) so callers can still proceed.
+    return false;
   }
-  return isFunctionReady;
 };
 
 export function selectFunctionFieldsForLogging(

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -20,7 +20,6 @@ import {
 import * as awsClients from "../src/aws-resources";
 import { baseInstrumentOutcome } from "./test-utils";
 import { waitUntilFunctionActiveV2 } from "@aws-sdk/client-lambda";
-import { WaiterState } from "@smithy/core/client";
 
 vi.mock("../src/aws-resources");
 vi.mock("@aws-sdk/client-lambda", async () => ({
@@ -1598,20 +1597,14 @@ describe("waitUntilFunctionIsActive", () => {
     vi.resetAllMocks();
   });
 
-  test("returns true when the SDK waiter reaches a SUCCESS state", async () => {
-    mockedWaiter.mockResolvedValue({ state: WaiterState.SUCCESS } as any);
+  test("returns true when the SDK waiter resolves (function reached Active)", async () => {
+    mockedWaiter.mockResolvedValue({} as any);
     const res = await waitUntilFunctionIsActive("test-function");
     expect(res).toStrictEqual(true);
     expect(mockedWaiter).toHaveBeenCalledTimes(1);
     expect(mockedWaiter).toHaveBeenCalledWith(expect.anything(), {
       FunctionName: "test-function",
     });
-  });
-
-  test("returns false when the SDK waiter ends in a non-success state", async () => {
-    mockedWaiter.mockResolvedValue({ state: WaiterState.TIMEOUT } as any);
-    const res = await waitUntilFunctionIsActive("test-function");
-    expect(res).toStrictEqual(false);
   });
 
   test("returns false (does not throw) when the SDK waiter throws", async () => {

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -18,11 +18,15 @@ import {
   DD_SERVERLESS_LOGS_ENABLED,
 } from "../src/consts";
 import * as awsClients from "../src/aws-resources";
-import * as sleep from "../src/sleep";
 import { baseInstrumentOutcome } from "./test-utils";
+import { waitUntilFunctionActiveV2 } from "@aws-sdk/client-lambda";
+import { WaiterState } from "@smithy/core/client";
 
 vi.mock("../src/aws-resources");
-vi.mock("../src/sleep");
+vi.mock("@aws-sdk/client-lambda", async () => ({
+  ...(await vi.importActual("@aws-sdk/client-lambda")),
+  waitUntilFunctionActiveV2: vi.fn(),
+}));
 
 // Creates a test config object
 function createTestConfig({
@@ -1588,38 +1592,32 @@ describe("isInstrumented", () => {
 });
 
 describe("waitUntilFunctionIsActive", () => {
+  const mockedWaiter = vi.mocked(waitUntilFunctionActiveV2);
+
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  test("stops when the status is active", async () => {
-    vi.mocked(awsClients.getLambdaClient).mockReturnValue({
-      send: () => ({ State: "Active" }),
-    } as any);
+  test("returns true when the SDK waiter reaches a SUCCESS state", async () => {
+    mockedWaiter.mockResolvedValue({ state: WaiterState.SUCCESS } as any);
     const res = await waitUntilFunctionIsActive("test-function");
     expect(res).toStrictEqual(true);
-    expect(sleep.sleep).toHaveBeenCalledTimes(0);
+    expect(mockedWaiter).toHaveBeenCalledTimes(1);
+    expect(mockedWaiter).toHaveBeenCalledWith(expect.anything(), {
+      FunctionName: "test-function",
+    });
   });
 
-  test("stops when the status is active after the second time", async () => {
-    vi.mocked(awsClients.getLambdaClient).mockReturnValue({
-      send: vi
-        .fn()
-        .mockReturnValueOnce({ State: "Pending" })
-        .mockReturnValueOnce({ State: "Active" }),
-    } as any);
-    const res = await waitUntilFunctionIsActive("test-function");
-    expect(res).toStrictEqual(true);
-    expect(sleep.sleep).toHaveBeenCalledTimes(1);
-  });
-
-  test("times out waiting when the status never exits", async () => {
-    vi.mocked(awsClients.getLambdaClient).mockReturnValue({
-      send: () => ({ State: "Pending" }),
-    } as any);
+  test("returns false when the SDK waiter ends in a non-success state", async () => {
+    mockedWaiter.mockResolvedValue({ state: WaiterState.TIMEOUT } as any);
     const res = await waitUntilFunctionIsActive("test-function");
     expect(res).toStrictEqual(false);
-    expect(sleep.sleep).toHaveBeenCalledTimes(10);
+  });
+
+  test("returns false (does not throw) when the SDK waiter throws", async () => {
+    mockedWaiter.mockRejectedValue(new Error("waiter timed out"));
+    const res = await waitUntilFunctionIsActive("test-function");
+    expect(res).toStrictEqual(false);
   });
 });
 


### PR DESCRIPTION
## What

Replaces the hand-rolled polling loop in `waitUntilFunctionIsActive` with the AWS SDK's built-in **`waitUntilFunctionActiveV2`** waiter. The waiter polls with exponential backoff and properly handles terminal states (e.g. `Failed`), instead of the manual `while`-loop with fixed 1-second `sleep`s.

## Underlying API

The V2 waiter polls the **`GetFunction`** API (not `GetFunctionConfiguration`, which the old loop used). Proof, from the canonical AWS SDK source:

https://github.com/aws/aws-sdk-js-v3/blob/main/clients/client-lambda/src/waiters/waitForFunctionActiveV2.ts

- `let result = await client.send(new GetFunctionCommand(input));`
- doc comment: *"This waiter uses GetFunction API."*

`lambda:GetFunction` is already granted to the instrumenter's execution role (`template.yaml`), so no IAM change is needed.

This is significant because GetFunction uses a separate AWS quota than GetFunctionConfiguration (which shares it with the update calls we do as part of Datadog CI) - [quotas](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html).  And the ceiling is pretty low, 15, so removing 1 per function we instrument actually has a large effect on the max rate we can instrument things at.  Otherwise there shouldn't be significant differences in this PR.

## Behavior preserved

`waitUntil*` **throws** on `TIMEOUT`/`FAILURE` (unlike the deprecated `waitFor*`), so the call is wrapped in try/catch to return `false` rather than throw — preserving the previous boolean contract so callers proceed unchanged. `maxWaitTime` of 10s keeps roughly the old ~10s ceiling.

## Changes
- `src/functions.ts` — swap the manual loop for `waitUntilFunctionActiveV2`; drop the now-unused `GetFunctionConfigurationCommand` and `sleep` imports.
- `test/functions.test.ts` — rewrite the three waiter tests to mock the SDK waiter and assert the wrapper's state→boolean contract (the old tests asserted on `sleep` call counts, which no longer apply).


🤖 Generated with [Claude Code](https://claude.com/claude-code)