### PR TITLE
Skip TagResources call when version tag is already current

### DIFF
--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -29,6 +29,7 @@ import {
   createFunction,
   deleteTestFunctions,
   createFunctions,
+  tagFunction,
 } from "./utilities/lambda-functions";
 import { Runtime } from "@aws-sdk/client-lambda";
 import {
@@ -436,6 +437,20 @@ describe("Remote instrumenter scheduled event tests", () => {
       getDeployedInstrumenterVersion(),
     ]);
     expect(tagValue).toBe(`v${deployedVersion}`);
+
+    // Reset the tag to an old version and re-invoke to confirm it gets corrected again
+    await tagFunction(functionName, {
+      dd_sls_remote_instrumenter_version: oldVersion,
+    });
+
+    await invokeLambdaWithScheduledEvent();
+
+    let correctedTagValue: string | undefined;
+    await pollUntilTrue(60000, 5000, async () => {
+      correctedTagValue = await getRemoteInstrumenterTagValue(functionArn);
+      return correctedTagValue === `v${deployedVersion}`;
+    });
+    expect(correctedTagValue).toBe(`v${deployedVersion}`);
   });
 
   it("instruments a function whose tag key uses colons when the rule filter uses underscores (REDAPL normalization)", async () => {

--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -13,6 +13,7 @@ import {
   isFunctionInstrumented,
   isFunctionUninstrumented,
   hasRemoteInstrumenterTag,
+  getRemoteInstrumenterTagValue,
   expectFunctionsToBeInstrumented,
 } from "./utilities/is-function-instrumented";
 import {
@@ -20,7 +21,10 @@ import {
   clearKnownRemoteConfigs,
   clearRemoteConfigs,
 } from "./utilities/remote-config";
-import { invokeLambdaWithScheduledEvent } from "./utilities/remote-instrumenter-invocations";
+import {
+  invokeLambdaWithScheduledEvent,
+  getDeployedInstrumenterVersion,
+} from "./utilities/remote-instrumenter-invocations";
 import {
   createFunction,
   deleteTestFunctions,
@@ -410,6 +414,28 @@ describe("Remote instrumenter scheduled event tests", () => {
       isFunctionInstrumented(functionName),
     );
     expect(isInstrumented).toStrictEqual(true);
+  });
+
+  it("updates an outdated instrumenter version tag to the current version", async () => {
+    const oldVersion = "v0.0.1";
+    const { FunctionName: functionName, FunctionArn: functionArn } =
+      await createFunction({
+        Tags: { foo: "bar", dd_sls_remote_instrumenter_version: oldVersion },
+      });
+    await setRemoteConfig();
+
+    await invokeLambdaWithScheduledEvent();
+
+    const isInstrumented = await pollUntilTrue(60000, 5000, () =>
+      isFunctionInstrumented(functionName),
+    );
+    expect(isInstrumented).toStrictEqual(true);
+
+    const [tagValue, deployedVersion] = await Promise.all([
+      getRemoteInstrumenterTagValue(functionArn),
+      getDeployedInstrumenterVersion(),
+    ]);
+    expect(tagValue).toBe(`v${deployedVersion}`);
   });
 
   it("instruments a function whose tag key uses colons when the rule filter uses underscores (REDAPL normalization)", async () => {

--- a/integration-tests/utilities/is-function-instrumented.ts
+++ b/integration-tests/utilities/is-function-instrumented.ts
@@ -57,6 +57,16 @@ const hasRemoteInstrumenterTag = async (
   }
 };
 
+const getRemoteInstrumenterTagValue = async (
+  functionArn: string,
+): Promise<string | undefined> => {
+  const lambdaClient = await getLambdaClient();
+  const tagsResponse = await lambdaClient.send(
+    new ListTagsCommand({ Resource: functionArn }),
+  );
+  return tagsResponse.Tags?.["dd_sls_remote_instrumenter_version"];
+};
+
 // A function is considered instrumented if all are true:
 // 1. If the extension layer is configured, there is a Datadog-Extension with matching version
 // 2. If there is a language layer configured, there should is a matching version of the language layer
@@ -180,6 +190,7 @@ const expectFunctionsToBeInstrumented = async (
 
 export {
   hasRemoteInstrumenterTag,
+  getRemoteInstrumenterTagValue,
   isFunctionInstrumented,
   isFunctionUninstrumented,
   expectFunctionsToBeInstrumented,

--- a/integration-tests/utilities/remote-instrumenter-invocations.ts
+++ b/integration-tests/utilities/remote-instrumenter-invocations.ts
@@ -1,4 +1,7 @@
-import { GetFunctionConfigurationCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  GetFunctionConfigurationCommand,
+  InvokeCommand,
+} from "@aws-sdk/client-lambda";
 import { getLambdaClient } from "./aws-resources";
 import { functionName } from "../config.json";
 import { createPresignedUrl, deleteObject } from "./s3-helpers";
@@ -106,7 +109,9 @@ const invokeLambdaWithCFNUpdateEvent =
     return invokeLambdaWithCFNEvent("Update");
   };
 
-const getDeployedInstrumenterVersion = async (): Promise<string | undefined> => {
+const getDeployedInstrumenterVersion = async (): Promise<
+  string | undefined
+> => {
   const lambdaClient = await getLambdaClient();
   const config = await lambdaClient.send(
     new GetFunctionConfigurationCommand({ FunctionName: functionName }),

--- a/integration-tests/utilities/remote-instrumenter-invocations.ts
+++ b/integration-tests/utilities/remote-instrumenter-invocations.ts
@@ -1,4 +1,4 @@
-import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { GetFunctionConfigurationCommand, InvokeCommand } from "@aws-sdk/client-lambda";
 import { getLambdaClient } from "./aws-resources";
 import { functionName } from "../config.json";
 import { createPresignedUrl, deleteObject } from "./s3-helpers";
@@ -106,10 +106,19 @@ const invokeLambdaWithCFNUpdateEvent =
     return invokeLambdaWithCFNEvent("Update");
   };
 
+const getDeployedInstrumenterVersion = async (): Promise<string | undefined> => {
+  const lambdaClient = await getLambdaClient();
+  const config = await lambdaClient.send(
+    new GetFunctionConfigurationCommand({ FunctionName: functionName }),
+  );
+  return config.Environment?.Variables?.DD_INSTRUMENTER_VERSION;
+};
+
 export {
   invokeLambdaWithScheduledEvent,
   invokeLambdaWithLambdaManagementEvent,
   invokeLambdaWithCFNDeleteEvent,
   invokeLambdaWithCFNCreateEvent,
   invokeLambdaWithCFNUpdateEvent,
+  getDeployedInstrumenterVersion,
 };

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -647,7 +647,12 @@ export function needsInstrumentationUpdate(
       reason: reason,
       reasonCode: ALREADY_CORRECT_EXTENSION_AND_LAYER,
     };
-    return { instrument: false, uninstrument: false, tag: false, untag: false };
+    return {
+      instrument: false,
+      uninstrument: false,
+      tag: !isTaggedWithCurrentVersion(lambdaFunc),
+      untag: false,
+    };
   }
 
   // Otherwise, instrument it. Skip tagging if the function already has the

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -326,7 +326,9 @@ export function isRemotelyInstrumented(lambdaFunc: LambdaFunction): boolean {
   return tagKeys.has(DD_SLS_REMOTE_INSTRUMENTER_VERSION);
 }
 
-export function isTaggedWithCurrentVersion(lambdaFunc: LambdaFunction): boolean {
+export function isTaggedWithCurrentVersion(
+  lambdaFunc: LambdaFunction,
+): boolean {
   const expectedTag = `${DD_SLS_REMOTE_INSTRUMENTER_VERSION}:v${VERSION}`;
   return (lambdaFunc.Tags as Set<string>).has(expectedTag);
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -326,6 +326,11 @@ export function isRemotelyInstrumented(lambdaFunc: LambdaFunction): boolean {
   return tagKeys.has(DD_SLS_REMOTE_INSTRUMENTER_VERSION);
 }
 
+export function isTaggedWithCurrentVersion(lambdaFunc: LambdaFunction): boolean {
+  const expectedTag = `${DD_SLS_REMOTE_INSTRUMENTER_VERSION}:v${VERSION}`;
+  return (lambdaFunc.Tags as Set<string>).has(expectedTag);
+}
+
 const hasLayerMatching = (l: LambdaFunction, matcher: string): boolean =>
   l?.Layers?.some((layer) => layer.Arn!.includes(matcher))!;
 
@@ -643,8 +648,14 @@ export function needsInstrumentationUpdate(
     return { instrument: false, uninstrument: false, tag: false, untag: false };
   }
 
-  // Otherwise, instrument it
-  return { instrument: true, uninstrument: false, tag: true, untag: false };
+  // Otherwise, instrument it. Skip tagging if the function already has the
+  // current version tag — avoids a TagResources call on re-instrumentation.
+  return {
+    instrument: true,
+    uninstrument: false,
+    tag: !isTaggedWithCurrentVersion(lambdaFunc),
+    untag: false,
+  };
 }
 
 // Max seconds to wait for a function to become Active before giving up.

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -7,6 +7,7 @@ import {
   needsInstrumentationUpdate,
   filterFunctionsToChangeInstrumentation,
   isInstrumented,
+  isTaggedWithCurrentVersion,
   waitUntilFunctionIsActive,
   selectFunctionFieldsForLogging,
   enrichFunctionsWithTags,
@@ -1336,24 +1337,13 @@ describe("needsInstrumentationUpdate", () => {
     });
   });
   describe("When the function needs to be instrumented", () => {
-    test("function should be instrumented and tagged", () => {
-      const layers = [
-        {
-          Arn: "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node:2",
-        },
-        {
-          Arn: "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:3",
-        },
-      ];
+    test("function without version tag should be instrumented and tagged", () => {
       const lambdaFunc = createTestLambdaFunction({
         functionName: "functionA",
         functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
         runtime: "nodejs14.x",
-        tags: new Set([
-          "foo:bar",
-          DD_SLS_REMOTE_INSTRUMENTER_VERSION + ":" + VERSION,
-        ]),
-        layers: layers,
+        tags: new Set(["foo:bar"]),
+        layers: [],
       });
       const ruleFilters = [
         {
@@ -1391,10 +1381,7 @@ describe("needsInstrumentationUpdate", () => {
         functionName: "functionA",
         functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
         runtime: "nodejs14.x",
-        tags: new Set([
-          "foo:bar",
-          DD_SLS_REMOTE_INSTRUMENTER_VERSION + ":" + VERSION,
-        ]),
+        tags: new Set(["foo:bar"]),
         layers: [],
         envVars: {},
       });
@@ -1428,6 +1415,116 @@ describe("needsInstrumentationUpdate", () => {
       expect(uninstrument).toBe(false);
       expect(tag).toBe(true);
       expect(untag).toBe(false);
+    });
+    test("function with current version tag should be instrumented but not re-tagged", () => {
+      const lambdaFunc = createTestLambdaFunction({
+        functionName: "functionA",
+        functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
+        runtime: "nodejs14.x",
+        tags: new Set([
+          "foo:bar",
+          `${DD_SLS_REMOTE_INSTRUMENTER_VERSION}:v${VERSION}`,
+        ]),
+        layers: [],
+        envVars: {},
+      });
+      const ruleFilters = [
+        {
+          key: "foo",
+          values: ["bar"],
+          allow: true,
+          filterType: "tag",
+        },
+      ];
+      const config = createTestConfig({
+        entityType: "lambda",
+        extensionVersion: 1,
+        nodeLayerVersion: 1,
+        pythonLayerVersion: 1,
+        ddTraceEnabled: true,
+        ddServerlessLogsEnabled: false,
+        priority: 1,
+        ruleFilters: ruleFilters,
+        instrumenterFunctionName: "datadog-remote-instrumenter",
+      });
+      const { instrument, uninstrument, tag, untag } =
+        needsInstrumentationUpdate(
+          lambdaFunc,
+          config,
+          baseInstrumentOutcome,
+          false,
+        );
+      expect(instrument).toBe(true);
+      expect(uninstrument).toBe(false);
+      expect(tag).toBe(false);
+      expect(untag).toBe(false);
+    });
+    test("function with outdated version tag should be instrumented and re-tagged", () => {
+      const lambdaFunc = createTestLambdaFunction({
+        functionName: "functionA",
+        functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
+        runtime: "nodejs14.x",
+        tags: new Set([
+          "foo:bar",
+          `${DD_SLS_REMOTE_INSTRUMENTER_VERSION}:v1.0.0`,
+        ]),
+        layers: [],
+        envVars: {},
+      });
+      const ruleFilters = [
+        {
+          key: "foo",
+          values: ["bar"],
+          allow: true,
+          filterType: "tag",
+        },
+      ];
+      const config = createTestConfig({
+        entityType: "lambda",
+        extensionVersion: 1,
+        nodeLayerVersion: 1,
+        pythonLayerVersion: 1,
+        ddTraceEnabled: true,
+        ddServerlessLogsEnabled: false,
+        priority: 1,
+        ruleFilters: ruleFilters,
+        instrumenterFunctionName: "datadog-remote-instrumenter",
+      });
+      const { instrument, uninstrument, tag, untag } =
+        needsInstrumentationUpdate(
+          lambdaFunc,
+          config,
+          baseInstrumentOutcome,
+          false,
+        );
+      expect(instrument).toBe(true);
+      expect(uninstrument).toBe(false);
+      expect(tag).toBe(true);
+      expect(untag).toBe(false);
+    });
+  });
+
+  describe("isTaggedWithCurrentVersion", () => {
+    test("returns true when function has current version tag", () => {
+      const lambdaFunc = createTestLambdaFunction({
+        functionName: "functionA",
+        tags: new Set([`${DD_SLS_REMOTE_INSTRUMENTER_VERSION}:v${VERSION}`]),
+      });
+      expect(isTaggedWithCurrentVersion(lambdaFunc)).toBe(true);
+    });
+    test("returns false when function has no version tag", () => {
+      const lambdaFunc = createTestLambdaFunction({
+        functionName: "functionA",
+        tags: new Set(["foo:bar"]),
+      });
+      expect(isTaggedWithCurrentVersion(lambdaFunc)).toBe(false);
+    });
+    test("returns false when function has outdated version tag", () => {
+      const lambdaFunc = createTestLambdaFunction({
+        functionName: "functionA",
+        tags: new Set([`${DD_SLS_REMOTE_INSTRUMENTER_VERSION}:v1.0.0`]),
+      });
+      expect(isTaggedWithCurrentVersion(lambdaFunc)).toBe(false);
     });
   });
 });

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -1297,7 +1297,7 @@ describe("needsInstrumentationUpdate", () => {
         runtime: "nodejs14.x",
         tags: new Set([
           "foo:bar",
-          DD_SLS_REMOTE_INSTRUMENTER_VERSION + ":" + VERSION,
+          `${DD_SLS_REMOTE_INSTRUMENTER_VERSION}:v${VERSION}`,
         ]),
         layers: layers,
         envVars: {
@@ -1333,6 +1333,59 @@ describe("needsInstrumentationUpdate", () => {
       expect(instrument).toBe(false);
       expect(uninstrument).toBe(false);
       expect(tag).toBe(false);
+      expect(untag).toBe(false);
+    });
+    test("correctly instrumented function with an outdated version tag should be retagged", () => {
+      const layers = [
+        {
+          Arn: "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node:1",
+        },
+        {
+          Arn: "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:1",
+        },
+      ];
+      const lambdaFunc = createTestLambdaFunction({
+        functionName: "functionA",
+        functionArn: "arn:aws:lambda:us-east-1:123456789012:function:functionA",
+        runtime: "nodejs14.x",
+        tags: new Set([
+          "foo:bar",
+          `${DD_SLS_REMOTE_INSTRUMENTER_VERSION}:v1.0.0`,
+        ]),
+        layers: layers,
+        envVars: {
+          [DD_TRACE_ENABLED]: "true",
+          [DD_SERVERLESS_LOGS_ENABLED]: "false",
+        },
+      });
+      const ruleFilters = [
+        {
+          key: "foo",
+          values: ["bar"],
+          allow: true,
+          filterType: "tag",
+        },
+      ];
+      const config = createTestConfig({
+        entityType: "lambda",
+        extensionVersion: 1,
+        nodeLayerVersion: 1,
+        pythonLayerVersion: 1,
+        ddTraceEnabled: true,
+        ddServerlessLogsEnabled: false,
+        priority: 1,
+        ruleFilters: ruleFilters,
+      });
+      const { instrument, uninstrument, tag, untag } =
+        needsInstrumentationUpdate(
+          lambdaFunc,
+          config,
+          baseInstrumentOutcome,
+          false,
+        );
+      expect(instrument).toBe(false);
+      expect(uninstrument).toBe(false);
+      expect(tag).toBe(true);
       expect(untag).toBe(false);
     });
   });

--- a/test/instrument.test.ts
+++ b/test/instrument.test.ts
@@ -217,6 +217,36 @@ describe("instrumentFunctions", () => {
     );
   });
 
+  test("should instrument but skip tagging a function that already has the current version tag", async () => {
+    const functionBaz: LambdaFunction = {
+      FunctionName: "baz",
+      FunctionArn: "arn:aws:lambda:us-east-2:123456789:function:baz",
+      Runtime: "nodejs18.x",
+      Tags: new Set([
+        "env:prod",
+        `${DD_SLS_REMOTE_INSTRUMENTER_VERSION}:v${VERSION}`,
+      ]),
+    };
+    (getInstrumentedFunctionConfig as any).mockResolvedValue({
+      functionARN: functionBaz.FunctionArn,
+      lambdaConfig: functionBaz,
+      updateFunctionConfigurationCommandInput: {},
+    });
+
+    await instrument.instrumentFunctions(
+      mockS3Client,
+      [rcConfig],
+      [functionBaz],
+      baseInstrumentOutcome,
+      mockTaggingClient,
+      SCHEDULED_INVOCATION_EVENT,
+    );
+
+    expect(getInstrumentedFunctionConfig).toHaveBeenCalledTimes(1);
+    expect(updateLambdaFunctionConfig).toHaveBeenCalledTimes(1);
+    expect(mockTaggingClient.send).not.toHaveBeenCalled();
+  });
+
   test("should uninstrument and untag functions that need it", async () => {
     await instrument.instrumentFunctions(
       mockS3Client,


### PR DESCRIPTION
## Summary
When re-instrumenting a function (e.g. a layer version bump rolling across all functions or after a customer updates their function and we need to re instrument it), `tagResourcesWithSlsTag` was called unconditionally — even when the function already had `dd_sls_remote_instrumenter_version` set to the current instrumenter version. This burned an unnecessary call against the Resource Groups Tagging API (5 req/sec shared pool) on every re-instrumentation pass.

This is significant because this is the bottleneck for how quickly we can instrument things.  The instrumenter will still run into this on instrumenting new functions or when the version updates, but those are outside of the most common path where a user updates their function and it needs reinstrumentation

- Adds `isTaggedWithCurrentVersion(lambdaFunc)` which checks for the exact tag key+value (`dd_sls_remote_instrumenter_version:v<VERSION>`) rather than just the key
- Changes `needsInstrumentationUpdate` to set `tag: !isTaggedWithCurrentVersion(lambdaFunc)` — `TagResources` is only called when the tag is absent or stale (different version)
- Functions being instrumented for the first time, or carrying an outdated version tag, still get tagged as before

## Tests
* Unit tests confirming this
* Integration test around updating the tag
