### PR TITLE
fix: skip container image Lambdas instead of crashing the batch

### DIFF
--- a/integration-tests/config.json.d.ts
+++ b/integration-tests/config.json.d.ts
@@ -11,7 +11,6 @@ declare const config: {
   version: string;
   apiSecretName: string;
   appSecretName: string;
-  containerImageFunctionName: string;
 };
 
 export = config;

--- a/integration-tests/config.json.d.ts
+++ b/integration-tests/config.json.d.ts
@@ -11,6 +11,7 @@ declare const config: {
   version: string;
   apiSecretName: string;
   appSecretName: string;
+  containerImageUri: string;
 };
 
 export = config;

--- a/integration-tests/config.json.d.ts
+++ b/integration-tests/config.json.d.ts
@@ -11,7 +11,7 @@ declare const config: {
   version: string;
   apiSecretName: string;
   appSecretName: string;
-  containerImageUri: string;
+  containerImageFunctionName: string;
 };
 
 export = config;

--- a/integration-tests/infrastructure/bin/infrastructure.ts
+++ b/integration-tests/infrastructure/bin/infrastructure.ts
@@ -9,6 +9,7 @@ import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
 import { DockerImageAsset, Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Construct } from 'constructs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { region, account, roleName, stackName, functionName, bucketName, testLambdaRole, ddSite, apiSecretName } from '../../config.json';
 import { readFileSync, writeFileSync } from 'fs'
 import { yamlParse, yamlDump } from 'yaml-cfn'
@@ -85,7 +86,7 @@ class TestingStack extends Stack {
     // the CDK bootstrap ECR repo during `cdk deploy`, keyed by Dockerfile hash
     // so it only rebuilds when the Dockerfile changes.
     const testContainerImage = new DockerImageAsset(this, 'TestContainerImage', {
-      directory: path.join(__dirname, '../../test-container'),
+      directory: path.join(path.dirname(fileURLToPath(import.meta.url)), '../../test-container'),
       platform: Platform.LINUX_AMD64,
     });
     new CfnOutput(this, 'TestContainerImageUri', {

--- a/integration-tests/infrastructure/bin/infrastructure.ts
+++ b/integration-tests/infrastructure/bin/infrastructure.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 import { App, CfnOutput, SecretValue, Stack, RemovalPolicy, Duration, Tags } from 'aws-cdk-lib';
 import { AccountRootPrincipal, Role, ServicePrincipal, PolicyStatement, CompositePrincipal, ManagedPolicy } from 'aws-cdk-lib/aws-iam';
-import { Function as LambdaFunction, Runtime, Code, Version, CfnFunction } from 'aws-cdk-lib/aws-lambda';
+import { Function as LambdaFunction, Runtime, Code, Version, DockerImageCode, DockerImageFunction } from 'aws-cdk-lib/aws-lambda';
 import { Distribution, LambdaEdgeEventType, ViewerProtocolPolicy } from 'aws-cdk-lib/aws-cloudfront';
 import { S3BucketOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import { Bucket, BlockPublicAccess } from 'aws-cdk-lib/aws-s3';
 import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
-import { DockerImageAsset, Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Construct } from 'constructs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -76,21 +76,29 @@ class TestingStack extends Stack {
       resources: ["*"],
     }));
 
-    new Role(this, 'TestLambdaExecutionRole', {
+    const testLambdaExecutionRole = new Role(this, 'TestLambdaExecutionRole', {
       assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
       roleName: testLambdaRole,
     });
 
-    // Minimal Lambda container image used by tests that verify the instrumenter
-    // skips container-image functions gracefully. CDK builds and pushes this to
-    // the CDK bootstrap ECR repo during `cdk deploy`, keyed by Dockerfile hash
-    // so it only rebuilds when the Dockerfile changes.
-    const testContainerImage = new DockerImageAsset(this, 'TestContainerImage', {
-      directory: path.join(path.dirname(fileURLToPath(import.meta.url)), '../../test-container'),
-      platform: Platform.LINUX_AMD64,
+    // A single container image Lambda shared across tests that verify the
+    // instrumenter skips PackageType:Image functions gracefully. CDK builds
+    // the image from test-container/Dockerfile and pushes it to the CDK
+    // bootstrap ECR repo during `cdk deploy` (requires DinD in CI).
+    // Tagged foo:bar so scheduled-event targeting rules pick it up automatically.
+    const containerImageFn = new DockerImageFunction(this, 'ContainerImageTestFn', {
+      code: DockerImageCode.fromImageAsset(
+        path.join(path.dirname(fileURLToPath(import.meta.url)), '../../test-container'),
+        { platform: Platform.LINUX_AMD64 },
+      ),
+      role: testLambdaExecutionRole,
+      memorySize: 128,
+      timeout: Duration.seconds(30),
     });
-    new CfnOutput(this, 'TestContainerImageUri', {
-      value: testContainerImage.imageUri,
+    Tags.of(containerImageFn).add('foo', 'bar');
+    Tags.of(containerImageFn).add('dd_serverless_service', 'remote_instrumenter_testing');
+    new CfnOutput(this, 'ContainerImageFunctionName', {
+      value: containerImageFn.functionName,
     });
 
     new CfnInclude(this, 'ImportedRemoteInstrumenterTemplate', {

--- a/integration-tests/infrastructure/bin/infrastructure.ts
+++ b/integration-tests/infrastructure/bin/infrastructure.ts
@@ -82,8 +82,9 @@ class TestingStack extends Stack {
     // A single container image Lambda shared across tests that verify the
     // instrumenter skips PackageType:Image functions gracefully. Uses the
     // self-monitoring-lambda-extension ECR repo in us-east-1 (sandbox-layer-deployer
-    // already has push permissions there). CI builds and pushes the image under
-    // the ci-test-container tag before cdk deploy.
+    // already has push permissions there). The image must be pushed manually — see
+    // the Confluence runbook for instructions:
+    // https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/3697541962/Lambda+Remote+Instrumentation
     // Tagged foo:bar so scheduled-event targeting rules pick it up automatically.
     const ecrRepo = Repository.fromRepositoryName(
       this, 'ContainerImageRepo', 'self-monitoring-lambda-extension'

--- a/integration-tests/infrastructure/bin/infrastructure.ts
+++ b/integration-tests/infrastructure/bin/infrastructure.ts
@@ -6,7 +6,9 @@ import { Distribution, LambdaEdgeEventType, ViewerProtocolPolicy } from 'aws-cdk
 import { S3BucketOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import { Bucket, BlockPublicAccess } from 'aws-cdk-lib/aws-s3';
 import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
+import { DockerImageAsset, Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Construct } from 'constructs';
+import path from 'path';
 import { region, account, roleName, stackName, functionName, bucketName, testLambdaRole, ddSite, apiSecretName } from '../../config.json';
 import { readFileSync, writeFileSync } from 'fs'
 import { yamlParse, yamlDump } from 'yaml-cfn'
@@ -76,6 +78,18 @@ class TestingStack extends Stack {
     new Role(this, 'TestLambdaExecutionRole', {
       assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
       roleName: testLambdaRole,
+    });
+
+    // Minimal Lambda container image used by tests that verify the instrumenter
+    // skips container-image functions gracefully. CDK builds and pushes this to
+    // the CDK bootstrap ECR repo during `cdk deploy`, keyed by Dockerfile hash
+    // so it only rebuilds when the Dockerfile changes.
+    const testContainerImage = new DockerImageAsset(this, 'TestContainerImage', {
+      directory: path.join(__dirname, '../../test-container'),
+      platform: Platform.LINUX_AMD64,
+    });
+    new CfnOutput(this, 'TestContainerImageUri', {
+      value: testContainerImage.imageUri,
     });
 
     new CfnInclude(this, 'ImportedRemoteInstrumenterTemplate', {

--- a/integration-tests/infrastructure/bin/infrastructure.ts
+++ b/integration-tests/infrastructure/bin/infrastructure.ts
@@ -80,16 +80,16 @@ class TestingStack extends Stack {
     });
 
     // A single container image Lambda shared across tests that verify the
-    // instrumenter skips PackageType:Image functions gracefully. References a
-    // pre-built image in a private ECR repo (one-time setup: push
-    // test-container/Dockerfile to remote-instrumenter-test-container in each
-    // CI region). No Docker daemon required during cdk deploy.
+    // instrumenter skips PackageType:Image functions gracefully. Uses the
+    // self-monitoring-lambda-extension ECR repo in us-east-1 (sandbox-layer-deployer
+    // already has push permissions there). CI builds and pushes the image under
+    // the ci-test-container tag before cdk deploy.
     // Tagged foo:bar so scheduled-event targeting rules pick it up automatically.
     const ecrRepo = Repository.fromRepositoryName(
-      this, 'ContainerImageRepo', 'remote-instrumenter-test-container'
+      this, 'ContainerImageRepo', 'self-monitoring-lambda-extension'
     );
     const containerImageFn = new DockerImageFunction(this, 'ContainerImageTestFn', {
-      code: DockerImageCode.fromEcrImage(ecrRepo, { tag: 'latest' }),
+      code: DockerImageCode.fromEcr(ecrRepo, { tag: 'ci-test-container' }),
       role: testLambdaExecutionRole,
       memorySize: 128,
       timeout: Duration.seconds(30),

--- a/integration-tests/infrastructure/bin/infrastructure.ts
+++ b/integration-tests/infrastructure/bin/infrastructure.ts
@@ -6,10 +6,8 @@ import { Distribution, LambdaEdgeEventType, ViewerProtocolPolicy } from 'aws-cdk
 import { S3BucketOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import { Bucket, BlockPublicAccess } from 'aws-cdk-lib/aws-s3';
 import { CfnInclude } from 'aws-cdk-lib/cloudformation-include';
-import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import { Repository } from 'aws-cdk-lib/aws-ecr';
 import { Construct } from 'constructs';
-import path from 'path';
-import { fileURLToPath } from 'url';
 import { region, account, roleName, stackName, functionName, bucketName, testLambdaRole, ddSite, apiSecretName } from '../../config.json';
 import { readFileSync, writeFileSync } from 'fs'
 import { yamlParse, yamlDump } from 'yaml-cfn'
@@ -82,15 +80,16 @@ class TestingStack extends Stack {
     });
 
     // A single container image Lambda shared across tests that verify the
-    // instrumenter skips PackageType:Image functions gracefully. CDK builds
-    // the image from test-container/Dockerfile and pushes it to the CDK
-    // bootstrap ECR repo during `cdk deploy` (requires DinD in CI).
+    // instrumenter skips PackageType:Image functions gracefully. References a
+    // pre-built image in a private ECR repo (one-time setup: push
+    // test-container/Dockerfile to remote-instrumenter-test-container in each
+    // CI region). No Docker daemon required during cdk deploy.
     // Tagged foo:bar so scheduled-event targeting rules pick it up automatically.
+    const ecrRepo = Repository.fromRepositoryName(
+      this, 'ContainerImageRepo', 'remote-instrumenter-test-container'
+    );
     const containerImageFn = new DockerImageFunction(this, 'ContainerImageTestFn', {
-      code: DockerImageCode.fromImageAsset(
-        path.join(path.dirname(fileURLToPath(import.meta.url)), '../../test-container'),
-        { platform: Platform.LINUX_AMD64 },
-      ),
+      code: DockerImageCode.fromEcrImage(ecrRepo, { tag: 'latest' }),
       role: testLambdaExecutionRole,
       memorySize: 128,
       timeout: Duration.seconds(30),

--- a/integration-tests/lambda-management-events.test.ts
+++ b/integration-tests/lambda-management-events.test.ts
@@ -29,7 +29,9 @@ import {
   invokeLambdaWithScheduledEvent,
   invokeLambdaWithLambdaManagementEvent,
 } from "./utilities/remote-instrumenter-invocations";
-import { containerImageUri } from "./config.json";
+import config from "./config.json";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const containerImageUri = (config as any).containerImageUri as string;
 
 describe("Remote instrumenter lambda management event tests", () => {
   afterAll(async () => {
@@ -231,41 +233,37 @@ describe("Remote instrumenter lambda management event tests", () => {
   // A lambda management event (e.g. UpdateFunctionConfiguration) targeting one
   // must be handled without throwing — otherwise the instrumenter Lambda itself
   // would crash and return a FunctionError, breaking the event pipeline.
-  it(
-    "container image Lambda (Runtime: undefined) is skipped without crashing the instrumenter",
-    async () => {
-      await setRemoteConfig();
+  it("container image Lambda (Runtime: undefined) is skipped without crashing the instrumenter", async () => {
+    await setRemoteConfig();
 
-      const { FunctionName: imageFunctionName } =
-        await createContainerImageFunction(containerImageUri, {
-          Tags: { foo: "bar" },
-        });
-
-      const { payload, errors } = await invokeLambdaWithLambdaManagementEvent({
-        targetFunctionName: imageFunctionName,
+    const { FunctionName: imageFunctionName } =
+      await createContainerImageFunction(containerImageUri, {
+        Tags: { foo: "bar" },
       });
 
-      // The instrumenter Lambda itself must not have errored.
-      expect(errors).toBeFalsy();
+    const { payload, errors } = await invokeLambdaWithLambdaManagementEvent({
+      targetFunctionName: imageFunctionName,
+    });
 
-      // The container image function must have been skipped, not succeeded or failed.
-      expect(Object.keys(payload.instrument.skipped)).toContain(
-        imageFunctionName,
-      );
-      expect(
-        payload.instrument.skipped[imageFunctionName].reasonCode,
-      ).toStrictEqual("unsupported-runtime");
-      expect(Object.keys(payload.instrument.succeeded)).not.toContain(
-        imageFunctionName,
-      );
-      expect(Object.keys(payload.instrument.failed)).not.toContain(
-        imageFunctionName,
-      );
+    // The instrumenter Lambda itself must not have errored.
+    expect(errors).toBeFalsy();
 
-      // And the function must remain un-instrumented.
-      const isUninstrumented =
-        await isFunctionUninstrumented(imageFunctionName);
-      expect(isUninstrumented).toStrictEqual(true);
-    },
-  );
+    // The container image function must have been skipped, not succeeded or failed.
+    expect(Object.keys(payload.instrument.skipped)).toContain(
+      imageFunctionName,
+    );
+    expect(
+      payload.instrument.skipped[imageFunctionName].reasonCode,
+    ).toStrictEqual("unsupported-runtime");
+    expect(Object.keys(payload.instrument.succeeded)).not.toContain(
+      imageFunctionName,
+    );
+    expect(Object.keys(payload.instrument.failed)).not.toContain(
+      imageFunctionName,
+    );
+
+    // And the function must remain un-instrumented.
+    const isUninstrumented = await isFunctionUninstrumented(imageFunctionName);
+    expect(isUninstrumented).toStrictEqual(true);
+  });
 });

--- a/integration-tests/lambda-management-events.test.ts
+++ b/integration-tests/lambda-management-events.test.ts
@@ -30,7 +30,8 @@ import {
 } from "./utilities/remote-instrumenter-invocations";
 import config from "./config.json";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const containerImageFunctionName = (config as any).containerImageFunctionName as string;
+const containerImageFunctionName = (config as any)
+  .containerImageFunctionName as string;
 
 describe("Remote instrumenter lambda management event tests", () => {
   afterAll(async () => {
@@ -258,7 +259,9 @@ describe("Remote instrumenter lambda management event tests", () => {
     );
 
     // And the function must remain un-instrumented.
-    const isUninstrumented = await isFunctionUninstrumented(containerImageFunctionName);
+    const isUninstrumented = await isFunctionUninstrumented(
+      containerImageFunctionName,
+    );
     expect(isUninstrumented).toStrictEqual(true);
   });
 });

--- a/integration-tests/lambda-management-events.test.ts
+++ b/integration-tests/lambda-management-events.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./utilities/remote-config";
 import {
   createFunction,
+  createContainerImageFunction,
   createFunctions,
   deleteTestFunctions,
   tagFunction,
@@ -28,6 +29,7 @@ import {
   invokeLambdaWithScheduledEvent,
   invokeLambdaWithLambdaManagementEvent,
 } from "./utilities/remote-instrumenter-invocations";
+import { containerImageUri } from "./config.json";
 
 describe("Remote instrumenter lambda management event tests", () => {
   afterAll(async () => {
@@ -223,5 +225,38 @@ describe("Remote instrumenter lambda management event tests", () => {
       targetFunctionName: "LambdaEventThisDoesNotExist",
     });
     expect(errors).toBeFalsy();
+  });
+
+  // Container image Lambdas have Runtime: undefined in API responses.
+  // A lambda management event (e.g. UpdateFunctionConfiguration) targeting one
+  // must be handled without throwing — otherwise the instrumenter Lambda itself
+  // would crash and return a FunctionError, breaking the event pipeline.
+  it("container image Lambda (Runtime: undefined) is skipped without crashing the instrumenter", async () => {
+    await setRemoteConfig();
+
+    const { FunctionName: imageFunctionName } = await createContainerImageFunction(
+      containerImageUri,
+      { Tags: { foo: "bar" } },
+    );
+
+    const { payload, errors } =
+      await invokeLambdaWithLambdaManagementEvent({
+        targetFunctionName: imageFunctionName,
+      });
+
+    // The instrumenter Lambda itself must not have errored.
+    expect(errors).toBeFalsy();
+
+    // The container image function must have been skipped, not succeeded or failed.
+    expect(Object.keys(payload.instrument.skipped)).toContain(imageFunctionName);
+    expect(payload.instrument.skipped[imageFunctionName].reasonCode).toStrictEqual(
+      "unsupported-runtime",
+    );
+    expect(Object.keys(payload.instrument.succeeded)).not.toContain(imageFunctionName);
+    expect(Object.keys(payload.instrument.failed)).not.toContain(imageFunctionName);
+
+    // And the function must remain un-instrumented.
+    const isUninstrumented = await isFunctionUninstrumented(imageFunctionName);
+    expect(isUninstrumented).toStrictEqual(true);
   });
 });

--- a/integration-tests/lambda-management-events.test.ts
+++ b/integration-tests/lambda-management-events.test.ts
@@ -29,10 +29,7 @@ import {
   invokeLambdaWithScheduledEvent,
   invokeLambdaWithLambdaManagementEvent,
 } from "./utilities/remote-instrumenter-invocations";
-import config from "./config.json";
-// containerImageUri is optional — add it to config.json during environment setup.
-// Tests that require it are skipped automatically when it's absent.
-const containerImageUri: string | undefined = (config as any).containerImageUri;
+import { containerImageUri } from "./config.json";
 
 describe("Remote instrumenter lambda management event tests", () => {
   afterAll(async () => {
@@ -234,13 +231,13 @@ describe("Remote instrumenter lambda management event tests", () => {
   // A lambda management event (e.g. UpdateFunctionConfiguration) targeting one
   // must be handled without throwing — otherwise the instrumenter Lambda itself
   // would crash and return a FunctionError, breaking the event pipeline.
-  it.skipIf(!containerImageUri)(
+  it(
     "container image Lambda (Runtime: undefined) is skipped without crashing the instrumenter",
     async () => {
       await setRemoteConfig();
 
       const { FunctionName: imageFunctionName } =
-        await createContainerImageFunction(containerImageUri!, {
+        await createContainerImageFunction(containerImageUri, {
           Tags: { foo: "bar" },
         });
 

--- a/integration-tests/lambda-management-events.test.ts
+++ b/integration-tests/lambda-management-events.test.ts
@@ -24,15 +24,12 @@ import {
   createFunctions,
   deleteTestFunctions,
   tagFunction,
+  CONTAINER_IMAGE_URI,
 } from "./utilities/lambda-functions";
 import {
   invokeLambdaWithScheduledEvent,
   invokeLambdaWithLambdaManagementEvent,
 } from "./utilities/remote-instrumenter-invocations";
-import config from "./config.json";
-// containerImageUri is optional — add it to config.json during environment setup.
-// Tests that require it are skipped automatically when it's absent.
-const containerImageUri: string | undefined = (config as any).containerImageUri;
 
 describe("Remote instrumenter lambda management event tests", () => {
   afterAll(async () => {
@@ -234,41 +231,37 @@ describe("Remote instrumenter lambda management event tests", () => {
   // A lambda management event (e.g. UpdateFunctionConfiguration) targeting one
   // must be handled without throwing — otherwise the instrumenter Lambda itself
   // would crash and return a FunctionError, breaking the event pipeline.
-  it.skipIf(!containerImageUri)(
-    "container image Lambda (Runtime: undefined) is skipped without crashing the instrumenter",
-    async () => {
-      await setRemoteConfig();
+  it("container image Lambda (Runtime: undefined) is skipped without crashing the instrumenter", async () => {
+    await setRemoteConfig();
 
-      const { FunctionName: imageFunctionName } =
-        await createContainerImageFunction(containerImageUri!, {
-          Tags: { foo: "bar" },
-        });
-
-      const { payload, errors } = await invokeLambdaWithLambdaManagementEvent({
-        targetFunctionName: imageFunctionName,
+    const { FunctionName: imageFunctionName } =
+      await createContainerImageFunction(CONTAINER_IMAGE_URI, {
+        Tags: { foo: "bar" },
       });
 
-      // The instrumenter Lambda itself must not have errored.
-      expect(errors).toBeFalsy();
+    const { payload, errors } = await invokeLambdaWithLambdaManagementEvent({
+      targetFunctionName: imageFunctionName,
+    });
 
-      // The container image function must have been skipped, not succeeded or failed.
-      expect(Object.keys(payload.instrument.skipped)).toContain(
-        imageFunctionName,
-      );
-      expect(
-        payload.instrument.skipped[imageFunctionName].reasonCode,
-      ).toStrictEqual("unsupported-runtime");
-      expect(Object.keys(payload.instrument.succeeded)).not.toContain(
-        imageFunctionName,
-      );
-      expect(Object.keys(payload.instrument.failed)).not.toContain(
-        imageFunctionName,
-      );
+    // The instrumenter Lambda itself must not have errored.
+    expect(errors).toBeFalsy();
 
-      // And the function must remain un-instrumented.
-      const isUninstrumented =
-        await isFunctionUninstrumented(imageFunctionName);
-      expect(isUninstrumented).toStrictEqual(true);
-    },
-  );
+    // The container image function must have been skipped, not succeeded or failed.
+    expect(Object.keys(payload.instrument.skipped)).toContain(
+      imageFunctionName,
+    );
+    expect(
+      payload.instrument.skipped[imageFunctionName].reasonCode,
+    ).toStrictEqual("unsupported-runtime");
+    expect(Object.keys(payload.instrument.succeeded)).not.toContain(
+      imageFunctionName,
+    );
+    expect(Object.keys(payload.instrument.failed)).not.toContain(
+      imageFunctionName,
+    );
+
+    // And the function must remain un-instrumented.
+    const isUninstrumented = await isFunctionUninstrumented(imageFunctionName);
+    expect(isUninstrumented).toStrictEqual(true);
+  });
 });

--- a/integration-tests/lambda-management-events.test.ts
+++ b/integration-tests/lambda-management-events.test.ts
@@ -20,7 +20,6 @@ import {
 } from "./utilities/remote-config";
 import {
   createFunction,
-  createContainerImageFunction,
   createFunctions,
   deleteTestFunctions,
   tagFunction,
@@ -31,7 +30,7 @@ import {
 } from "./utilities/remote-instrumenter-invocations";
 import config from "./config.json";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const containerImageUri = (config as any).containerImageUri as string;
+const containerImageFunctionName = (config as any).containerImageFunctionName as string;
 
 describe("Remote instrumenter lambda management event tests", () => {
   afterAll(async () => {
@@ -236,13 +235,9 @@ describe("Remote instrumenter lambda management event tests", () => {
   it("container image Lambda (Runtime: undefined) is skipped without crashing the instrumenter", async () => {
     await setRemoteConfig();
 
-    const { FunctionName: imageFunctionName } =
-      await createContainerImageFunction(containerImageUri, {
-        Tags: { foo: "bar" },
-      });
-
+    // Use the container image Lambda pre-created in CDK — no per-test create/delete needed.
     const { payload, errors } = await invokeLambdaWithLambdaManagementEvent({
-      targetFunctionName: imageFunctionName,
+      targetFunctionName: containerImageFunctionName,
     });
 
     // The instrumenter Lambda itself must not have errored.
@@ -250,20 +245,20 @@ describe("Remote instrumenter lambda management event tests", () => {
 
     // The container image function must have been skipped, not succeeded or failed.
     expect(Object.keys(payload.instrument.skipped)).toContain(
-      imageFunctionName,
+      containerImageFunctionName,
     );
     expect(
-      payload.instrument.skipped[imageFunctionName].reasonCode,
+      payload.instrument.skipped[containerImageFunctionName].reasonCode,
     ).toStrictEqual("unsupported-runtime");
     expect(Object.keys(payload.instrument.succeeded)).not.toContain(
-      imageFunctionName,
+      containerImageFunctionName,
     );
     expect(Object.keys(payload.instrument.failed)).not.toContain(
-      imageFunctionName,
+      containerImageFunctionName,
     );
 
     // And the function must remain un-instrumented.
-    const isUninstrumented = await isFunctionUninstrumented(imageFunctionName);
+    const isUninstrumented = await isFunctionUninstrumented(containerImageFunctionName);
     expect(isUninstrumented).toStrictEqual(true);
   });
 });

--- a/integration-tests/lambda-management-events.test.ts
+++ b/integration-tests/lambda-management-events.test.ts
@@ -182,14 +182,16 @@ describe("Remote instrumenter lambda management event tests", () => {
     );
     const functionNames = functions.map((lambda: any) => lambda.FunctionName);
 
-    // For each of the 20 functions
-    for (const functionName of functionNames) {
-      // After some time
-      const isInstrumented = await pollUntilTrue(60000, 5000, () =>
-        isFunctionInstrumented(functionName),
-      );
+    // Poll all 20 functions concurrently — they all receive management events
+    // at roughly the same time, so sequential polling would time out.
+    const results = await Promise.all(
+      functionNames.map((functionName: string) =>
+        pollUntilTrue(60000, 5000, () => isFunctionInstrumented(functionName)),
+      ),
+    );
 
-      // The function is instrumented correctly
+    // Every function must be instrumented
+    for (const isInstrumented of results) {
       expect(isInstrumented).toStrictEqual(true);
     }
   }, 120000);

--- a/integration-tests/lambda-management-events.test.ts
+++ b/integration-tests/lambda-management-events.test.ts
@@ -29,7 +29,10 @@ import {
   invokeLambdaWithScheduledEvent,
   invokeLambdaWithLambdaManagementEvent,
 } from "./utilities/remote-instrumenter-invocations";
-import { containerImageUri } from "./config.json";
+import config from "./config.json";
+// containerImageUri is optional — add it to config.json during environment setup.
+// Tests that require it are skipped automatically when it's absent.
+const containerImageUri: string | undefined = (config as any).containerImageUri;
 
 describe("Remote instrumenter lambda management event tests", () => {
   afterAll(async () => {
@@ -231,32 +234,41 @@ describe("Remote instrumenter lambda management event tests", () => {
   // A lambda management event (e.g. UpdateFunctionConfiguration) targeting one
   // must be handled without throwing — otherwise the instrumenter Lambda itself
   // would crash and return a FunctionError, breaking the event pipeline.
-  it("container image Lambda (Runtime: undefined) is skipped without crashing the instrumenter", async () => {
-    await setRemoteConfig();
+  it.skipIf(!containerImageUri)(
+    "container image Lambda (Runtime: undefined) is skipped without crashing the instrumenter",
+    async () => {
+      await setRemoteConfig();
 
-    const { FunctionName: imageFunctionName } = await createContainerImageFunction(
-      containerImageUri,
-      { Tags: { foo: "bar" } },
-    );
+      const { FunctionName: imageFunctionName } =
+        await createContainerImageFunction(containerImageUri!, {
+          Tags: { foo: "bar" },
+        });
 
-    const { payload, errors } =
-      await invokeLambdaWithLambdaManagementEvent({
+      const { payload, errors } = await invokeLambdaWithLambdaManagementEvent({
         targetFunctionName: imageFunctionName,
       });
 
-    // The instrumenter Lambda itself must not have errored.
-    expect(errors).toBeFalsy();
+      // The instrumenter Lambda itself must not have errored.
+      expect(errors).toBeFalsy();
 
-    // The container image function must have been skipped, not succeeded or failed.
-    expect(Object.keys(payload.instrument.skipped)).toContain(imageFunctionName);
-    expect(payload.instrument.skipped[imageFunctionName].reasonCode).toStrictEqual(
-      "unsupported-runtime",
-    );
-    expect(Object.keys(payload.instrument.succeeded)).not.toContain(imageFunctionName);
-    expect(Object.keys(payload.instrument.failed)).not.toContain(imageFunctionName);
+      // The container image function must have been skipped, not succeeded or failed.
+      expect(Object.keys(payload.instrument.skipped)).toContain(
+        imageFunctionName,
+      );
+      expect(
+        payload.instrument.skipped[imageFunctionName].reasonCode,
+      ).toStrictEqual("unsupported-runtime");
+      expect(Object.keys(payload.instrument.succeeded)).not.toContain(
+        imageFunctionName,
+      );
+      expect(Object.keys(payload.instrument.failed)).not.toContain(
+        imageFunctionName,
+      );
 
-    // And the function must remain un-instrumented.
-    const isUninstrumented = await isFunctionUninstrumented(imageFunctionName);
-    expect(isUninstrumented).toStrictEqual(true);
-  });
+      // And the function must remain un-instrumented.
+      const isUninstrumented =
+        await isFunctionUninstrumented(imageFunctionName);
+      expect(isUninstrumented).toStrictEqual(true);
+    },
+  );
 });

--- a/integration-tests/lambda-management-events.test.ts
+++ b/integration-tests/lambda-management-events.test.ts
@@ -28,10 +28,7 @@ import {
   invokeLambdaWithScheduledEvent,
   invokeLambdaWithLambdaManagementEvent,
 } from "./utilities/remote-instrumenter-invocations";
-import config from "./config.json";
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const containerImageFunctionName = (config as any)
-  .containerImageFunctionName as string;
+import { getContainerImageFunctionName } from "./utilities/aws-resources";
 
 describe("Remote instrumenter lambda management event tests", () => {
   afterAll(async () => {
@@ -237,6 +234,7 @@ describe("Remote instrumenter lambda management event tests", () => {
     await setRemoteConfig();
 
     // Use the container image Lambda pre-created in CDK — no per-test create/delete needed.
+    const containerImageFunctionName = await getContainerImageFunctionName();
     const { payload, errors } = await invokeLambdaWithLambdaManagementEvent({
       targetFunctionName: containerImageFunctionName,
     });

--- a/integration-tests/lambda-management-events.test.ts
+++ b/integration-tests/lambda-management-events.test.ts
@@ -24,12 +24,15 @@ import {
   createFunctions,
   deleteTestFunctions,
   tagFunction,
-  CONTAINER_IMAGE_URI,
 } from "./utilities/lambda-functions";
 import {
   invokeLambdaWithScheduledEvent,
   invokeLambdaWithLambdaManagementEvent,
 } from "./utilities/remote-instrumenter-invocations";
+import config from "./config.json";
+// containerImageUri is optional — add it to config.json during environment setup.
+// Tests that require it are skipped automatically when it's absent.
+const containerImageUri: string | undefined = (config as any).containerImageUri;
 
 describe("Remote instrumenter lambda management event tests", () => {
   afterAll(async () => {
@@ -231,37 +234,41 @@ describe("Remote instrumenter lambda management event tests", () => {
   // A lambda management event (e.g. UpdateFunctionConfiguration) targeting one
   // must be handled without throwing — otherwise the instrumenter Lambda itself
   // would crash and return a FunctionError, breaking the event pipeline.
-  it("container image Lambda (Runtime: undefined) is skipped without crashing the instrumenter", async () => {
-    await setRemoteConfig();
+  it.skipIf(!containerImageUri)(
+    "container image Lambda (Runtime: undefined) is skipped without crashing the instrumenter",
+    async () => {
+      await setRemoteConfig();
 
-    const { FunctionName: imageFunctionName } =
-      await createContainerImageFunction(CONTAINER_IMAGE_URI, {
-        Tags: { foo: "bar" },
+      const { FunctionName: imageFunctionName } =
+        await createContainerImageFunction(containerImageUri!, {
+          Tags: { foo: "bar" },
+        });
+
+      const { payload, errors } = await invokeLambdaWithLambdaManagementEvent({
+        targetFunctionName: imageFunctionName,
       });
 
-    const { payload, errors } = await invokeLambdaWithLambdaManagementEvent({
-      targetFunctionName: imageFunctionName,
-    });
+      // The instrumenter Lambda itself must not have errored.
+      expect(errors).toBeFalsy();
 
-    // The instrumenter Lambda itself must not have errored.
-    expect(errors).toBeFalsy();
+      // The container image function must have been skipped, not succeeded or failed.
+      expect(Object.keys(payload.instrument.skipped)).toContain(
+        imageFunctionName,
+      );
+      expect(
+        payload.instrument.skipped[imageFunctionName].reasonCode,
+      ).toStrictEqual("unsupported-runtime");
+      expect(Object.keys(payload.instrument.succeeded)).not.toContain(
+        imageFunctionName,
+      );
+      expect(Object.keys(payload.instrument.failed)).not.toContain(
+        imageFunctionName,
+      );
 
-    // The container image function must have been skipped, not succeeded or failed.
-    expect(Object.keys(payload.instrument.skipped)).toContain(
-      imageFunctionName,
-    );
-    expect(
-      payload.instrument.skipped[imageFunctionName].reasonCode,
-    ).toStrictEqual("unsupported-runtime");
-    expect(Object.keys(payload.instrument.succeeded)).not.toContain(
-      imageFunctionName,
-    );
-    expect(Object.keys(payload.instrument.failed)).not.toContain(
-      imageFunctionName,
-    );
-
-    // And the function must remain un-instrumented.
-    const isUninstrumented = await isFunctionUninstrumented(imageFunctionName);
-    expect(isUninstrumented).toStrictEqual(true);
-  });
+      // And the function must remain un-instrumented.
+      const isUninstrumented =
+        await isFunctionUninstrumented(imageFunctionName);
+      expect(isUninstrumented).toStrictEqual(true);
+    },
+  );
 });

--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -27,7 +27,6 @@ import {
 } from "./utilities/remote-instrumenter-invocations";
 import {
   createFunction,
-  createContainerImageFunction,
   deleteTestFunctions,
   createFunctions,
   tagFunction,
@@ -40,7 +39,7 @@ import {
 } from "./utilities/s3-error-object";
 import config, { region } from "./config.json";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const containerImageUri = (config as any).containerImageUri as string;
+const containerImageFunctionName = (config as any).containerImageFunctionName as string;
 
 describe("Remote instrumenter scheduled event tests", () => {
   const functionThatDoesntExist = "ThisDoesNotExist";
@@ -513,29 +512,25 @@ describe("Remote instrumenter scheduled event tests", () => {
       Tags: { foo: "bar" },
     });
 
-    // Create a container image function with tags that match the targeting rule.
-    // Its Runtime will be undefined in the Lambda API response.
-    const { FunctionName: imageFunctionName } =
-      await createContainerImageFunction(containerImageUri, {
-        Tags: { foo: "bar" },
-      });
-
+    // The container image Lambda is pre-created in CDK (tagged foo:bar) so it is
+    // automatically picked up by the scheduled event targeting rule — no per-test
+    // create/delete needed.
     const res = await invokeLambdaWithScheduledEvent();
 
     // The container image function must appear in skipped with unsupported-runtime,
     // not in failed and not in succeeded.
-    expect(Object.keys(res.instrument.skipped)).toContain(imageFunctionName);
-    expect(res.instrument.skipped[imageFunctionName].reasonCode).toStrictEqual(
+    expect(Object.keys(res.instrument.skipped)).toContain(containerImageFunctionName);
+    expect(res.instrument.skipped[containerImageFunctionName].reasonCode).toStrictEqual(
       "unsupported-runtime",
     );
-    expect(Object.keys(res.instrument.failed)).not.toContain(imageFunctionName);
+    expect(Object.keys(res.instrument.failed)).not.toContain(containerImageFunctionName);
     expect(Object.keys(res.instrument.succeeded)).not.toContain(
-      imageFunctionName,
+      containerImageFunctionName,
     );
 
     // The container image function must remain un-instrumented (no layers, no env vars).
     const isImageFunctionUninstrumented =
-      await isFunctionUninstrumented(imageFunctionName);
+      await isFunctionUninstrumented(containerImageFunctionName);
     expect(isImageFunctionUninstrumented).toStrictEqual(true);
 
     // The zip-based function in the same batch must still have been instrumented,

--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -37,10 +37,8 @@ import {
   putErrorObject,
   doesErrorObjectExist,
 } from "./utilities/s3-error-object";
-import config, { region } from "./config.json";
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const containerImageFunctionName = (config as any)
-  .containerImageFunctionName as string;
+import { region } from "./config.json";
+import { getContainerImageFunctionName } from "./utilities/aws-resources";
 
 describe("Remote instrumenter scheduled event tests", () => {
   const functionThatDoesntExist = "ThisDoesNotExist";
@@ -516,6 +514,7 @@ describe("Remote instrumenter scheduled event tests", () => {
     // The container image Lambda is pre-created in CDK (tagged foo:bar) so it is
     // automatically picked up by the scheduled event targeting rule — no per-test
     // create/delete needed.
+    const containerImageFunctionName = await getContainerImageFunctionName();
     const res = await invokeLambdaWithScheduledEvent();
 
     // The container image function must appear in skipped with unsupported-runtime,

--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -38,12 +38,7 @@ import {
   putErrorObject,
   doesErrorObjectExist,
 } from "./utilities/s3-error-object";
-import { region } from "./config.json";
-// containerImageUri is optional — add it to config.json during environment setup.
-// Tests that require it are skipped automatically when it's absent.
-import configJson from "./config.json";
-const containerImageUri: string | undefined = (configJson as any)
-  .containerImageUri;
+import { region, containerImageUri } from "./config.json";
 
 describe("Remote instrumenter scheduled event tests", () => {
   const functionThatDoesntExist = "ThisDoesNotExist";
@@ -508,7 +503,7 @@ describe("Remote instrumenter scheduled event tests", () => {
   // The instrumenter must skip them gracefully rather than crashing the batch:
   // a TypeError in isSupportedRuntime would previously abort the entire scheduled run,
   // leaving all other functions in the account un-instrumented as well.
-  it.skipIf(!containerImageUri)(
+  it(
     "container image Lambda (Runtime: undefined) is skipped without crashing the batch",
     async () => {
       await setRemoteConfig();
@@ -521,7 +516,7 @@ describe("Remote instrumenter scheduled event tests", () => {
       // Create a container image function with tags that match the targeting rule.
       // Its Runtime will be undefined in the Lambda API response.
       const { FunctionName: imageFunctionName } =
-        await createContainerImageFunction(containerImageUri!, {
+        await createContainerImageFunction(containerImageUri, {
           Tags: { foo: "bar" },
         });
 

--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -27,6 +27,7 @@ import {
 } from "./utilities/remote-instrumenter-invocations";
 import {
   createFunction,
+  createContainerImageFunction,
   deleteTestFunctions,
   createFunctions,
   tagFunction,
@@ -37,7 +38,7 @@ import {
   putErrorObject,
   doesErrorObjectExist,
 } from "./utilities/s3-error-object";
-import { region } from "./config.json";
+import { region, containerImageUri } from "./config.json";
 
 describe("Remote instrumenter scheduled event tests", () => {
   const functionThatDoesntExist = "ThisDoesNotExist";
@@ -496,6 +497,48 @@ describe("Remote instrumenter scheduled event tests", () => {
 
     const hasTag = await hasRemoteInstrumenterTag(functionArn);
     expect(hasTag).toStrictEqual(false);
+  });
+
+  // Container image Lambdas have Runtime: undefined in API responses.
+  // The instrumenter must skip them gracefully rather than crashing the batch:
+  // a TypeError in isSupportedRuntime would previously abort the entire scheduled run,
+  // leaving all other functions in the account un-instrumented as well.
+  it("container image Lambda (Runtime: undefined) is skipped without crashing the batch", async () => {
+    await setRemoteConfig();
+
+    // Create one zip-based function that should get instrumented
+    const { FunctionName: zipFunctionName } = await createFunction({
+      Tags: { foo: "bar" },
+    });
+
+    // Create a container image function with tags that match the targeting rule.
+    // Its Runtime will be undefined in the Lambda API response.
+    const { FunctionName: imageFunctionName } = await createContainerImageFunction(
+      containerImageUri,
+      { Tags: { foo: "bar" } },
+    );
+
+    const res = await invokeLambdaWithScheduledEvent();
+
+    // The container image function must appear in skipped with unsupported-runtime,
+    // not in failed and not in succeeded.
+    expect(Object.keys(res.instrument.skipped)).toContain(imageFunctionName);
+    expect(res.instrument.skipped[imageFunctionName].reasonCode).toStrictEqual(
+      "unsupported-runtime",
+    );
+    expect(Object.keys(res.instrument.failed)).not.toContain(imageFunctionName);
+    expect(Object.keys(res.instrument.succeeded)).not.toContain(imageFunctionName);
+
+    // The container image function must remain un-instrumented (no layers, no env vars).
+    const isImageFunctionUninstrumented = await isFunctionUninstrumented(imageFunctionName);
+    expect(isImageFunctionUninstrumented).toStrictEqual(true);
+
+    // The zip-based function in the same batch must still have been instrumented,
+    // proving the container image function did not crash the batch.
+    const isZipFunctionInstrumented = await pollUntilTrue(60000, 5000, () =>
+      isFunctionInstrumented(zipFunctionName),
+    );
+    expect(isZipFunctionInstrumented).toStrictEqual(true);
   });
 
   it("correctly tags instrumented functions", async () => {

--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -38,7 +38,11 @@ import {
   putErrorObject,
   doesErrorObjectExist,
 } from "./utilities/s3-error-object";
-import { region, containerImageUri } from "./config.json";
+import config from "./config.json";
+const { region } = config;
+// containerImageUri is optional — add it to config.json during environment setup.
+// Tests that require it are skipped automatically when it's absent.
+const containerImageUri: string | undefined = (config as any).containerImageUri;
 
 describe("Remote instrumenter scheduled event tests", () => {
   const functionThatDoesntExist = "ThisDoesNotExist";
@@ -503,43 +507,51 @@ describe("Remote instrumenter scheduled event tests", () => {
   // The instrumenter must skip them gracefully rather than crashing the batch:
   // a TypeError in isSupportedRuntime would previously abort the entire scheduled run,
   // leaving all other functions in the account un-instrumented as well.
-  it("container image Lambda (Runtime: undefined) is skipped without crashing the batch", async () => {
-    await setRemoteConfig();
+  it.skipIf(!containerImageUri)(
+    "container image Lambda (Runtime: undefined) is skipped without crashing the batch",
+    async () => {
+      await setRemoteConfig();
 
-    // Create one zip-based function that should get instrumented
-    const { FunctionName: zipFunctionName } = await createFunction({
-      Tags: { foo: "bar" },
-    });
+      // Create one zip-based function that should get instrumented
+      const { FunctionName: zipFunctionName } = await createFunction({
+        Tags: { foo: "bar" },
+      });
 
-    // Create a container image function with tags that match the targeting rule.
-    // Its Runtime will be undefined in the Lambda API response.
-    const { FunctionName: imageFunctionName } = await createContainerImageFunction(
-      containerImageUri,
-      { Tags: { foo: "bar" } },
-    );
+      // Create a container image function with tags that match the targeting rule.
+      // Its Runtime will be undefined in the Lambda API response.
+      const { FunctionName: imageFunctionName } =
+        await createContainerImageFunction(containerImageUri!, {
+          Tags: { foo: "bar" },
+        });
 
-    const res = await invokeLambdaWithScheduledEvent();
+      const res = await invokeLambdaWithScheduledEvent();
 
-    // The container image function must appear in skipped with unsupported-runtime,
-    // not in failed and not in succeeded.
-    expect(Object.keys(res.instrument.skipped)).toContain(imageFunctionName);
-    expect(res.instrument.skipped[imageFunctionName].reasonCode).toStrictEqual(
-      "unsupported-runtime",
-    );
-    expect(Object.keys(res.instrument.failed)).not.toContain(imageFunctionName);
-    expect(Object.keys(res.instrument.succeeded)).not.toContain(imageFunctionName);
+      // The container image function must appear in skipped with unsupported-runtime,
+      // not in failed and not in succeeded.
+      expect(Object.keys(res.instrument.skipped)).toContain(imageFunctionName);
+      expect(
+        res.instrument.skipped[imageFunctionName].reasonCode,
+      ).toStrictEqual("unsupported-runtime");
+      expect(Object.keys(res.instrument.failed)).not.toContain(
+        imageFunctionName,
+      );
+      expect(Object.keys(res.instrument.succeeded)).not.toContain(
+        imageFunctionName,
+      );
 
-    // The container image function must remain un-instrumented (no layers, no env vars).
-    const isImageFunctionUninstrumented = await isFunctionUninstrumented(imageFunctionName);
-    expect(isImageFunctionUninstrumented).toStrictEqual(true);
+      // The container image function must remain un-instrumented (no layers, no env vars).
+      const isImageFunctionUninstrumented =
+        await isFunctionUninstrumented(imageFunctionName);
+      expect(isImageFunctionUninstrumented).toStrictEqual(true);
 
-    // The zip-based function in the same batch must still have been instrumented,
-    // proving the container image function did not crash the batch.
-    const isZipFunctionInstrumented = await pollUntilTrue(60000, 5000, () =>
-      isFunctionInstrumented(zipFunctionName),
-    );
-    expect(isZipFunctionInstrumented).toStrictEqual(true);
-  });
+      // The zip-based function in the same batch must still have been instrumented,
+      // proving the container image function did not crash the batch.
+      const isZipFunctionInstrumented = await pollUntilTrue(60000, 5000, () =>
+        isFunctionInstrumented(zipFunctionName),
+      );
+      expect(isZipFunctionInstrumented).toStrictEqual(true);
+    },
+  );
 
   it("correctly tags instrumented functions", async () => {
     const functions = await createFunctions({}, 51);

--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -31,7 +31,6 @@ import {
   deleteTestFunctions,
   createFunctions,
   tagFunction,
-  CONTAINER_IMAGE_URI,
 } from "./utilities/lambda-functions";
 import { Runtime } from "@aws-sdk/client-lambda";
 import {
@@ -40,6 +39,11 @@ import {
   doesErrorObjectExist,
 } from "./utilities/s3-error-object";
 import { region } from "./config.json";
+// containerImageUri is optional — add it to config.json during environment setup.
+// Tests that require it are skipped automatically when it's absent.
+import configJson from "./config.json";
+const containerImageUri: string | undefined = (configJson as any)
+  .containerImageUri;
 
 describe("Remote instrumenter scheduled event tests", () => {
   const functionThatDoesntExist = "ThisDoesNotExist";
@@ -504,46 +508,51 @@ describe("Remote instrumenter scheduled event tests", () => {
   // The instrumenter must skip them gracefully rather than crashing the batch:
   // a TypeError in isSupportedRuntime would previously abort the entire scheduled run,
   // leaving all other functions in the account un-instrumented as well.
-  it("container image Lambda (Runtime: undefined) is skipped without crashing the batch", async () => {
-    await setRemoteConfig();
+  it.skipIf(!containerImageUri)(
+    "container image Lambda (Runtime: undefined) is skipped without crashing the batch",
+    async () => {
+      await setRemoteConfig();
 
-    // Create one zip-based function that should get instrumented
-    const { FunctionName: zipFunctionName } = await createFunction({
-      Tags: { foo: "bar" },
-    });
-
-    // Create a container image function with tags that match the targeting rule.
-    // Its Runtime will be undefined in the Lambda API response.
-    const { FunctionName: imageFunctionName } =
-      await createContainerImageFunction(CONTAINER_IMAGE_URI, {
+      // Create one zip-based function that should get instrumented
+      const { FunctionName: zipFunctionName } = await createFunction({
         Tags: { foo: "bar" },
       });
 
-    const res = await invokeLambdaWithScheduledEvent();
+      // Create a container image function with tags that match the targeting rule.
+      // Its Runtime will be undefined in the Lambda API response.
+      const { FunctionName: imageFunctionName } =
+        await createContainerImageFunction(containerImageUri!, {
+          Tags: { foo: "bar" },
+        });
 
-    // The container image function must appear in skipped with unsupported-runtime,
-    // not in failed and not in succeeded.
-    expect(Object.keys(res.instrument.skipped)).toContain(imageFunctionName);
-    expect(res.instrument.skipped[imageFunctionName].reasonCode).toStrictEqual(
-      "unsupported-runtime",
-    );
-    expect(Object.keys(res.instrument.failed)).not.toContain(imageFunctionName);
-    expect(Object.keys(res.instrument.succeeded)).not.toContain(
-      imageFunctionName,
-    );
+      const res = await invokeLambdaWithScheduledEvent();
 
-    // The container image function must remain un-instrumented (no layers, no env vars).
-    const isImageFunctionUninstrumented =
-      await isFunctionUninstrumented(imageFunctionName);
-    expect(isImageFunctionUninstrumented).toStrictEqual(true);
+      // The container image function must appear in skipped with unsupported-runtime,
+      // not in failed and not in succeeded.
+      expect(Object.keys(res.instrument.skipped)).toContain(imageFunctionName);
+      expect(
+        res.instrument.skipped[imageFunctionName].reasonCode,
+      ).toStrictEqual("unsupported-runtime");
+      expect(Object.keys(res.instrument.failed)).not.toContain(
+        imageFunctionName,
+      );
+      expect(Object.keys(res.instrument.succeeded)).not.toContain(
+        imageFunctionName,
+      );
 
-    // The zip-based function in the same batch must still have been instrumented,
-    // proving the container image function did not crash the batch.
-    const isZipFunctionInstrumented = await pollUntilTrue(60000, 5000, () =>
-      isFunctionInstrumented(zipFunctionName),
-    );
-    expect(isZipFunctionInstrumented).toStrictEqual(true);
-  });
+      // The container image function must remain un-instrumented (no layers, no env vars).
+      const isImageFunctionUninstrumented =
+        await isFunctionUninstrumented(imageFunctionName);
+      expect(isImageFunctionUninstrumented).toStrictEqual(true);
+
+      // The zip-based function in the same batch must still have been instrumented,
+      // proving the container image function did not crash the batch.
+      const isZipFunctionInstrumented = await pollUntilTrue(60000, 5000, () =>
+        isFunctionInstrumented(zipFunctionName),
+      );
+      expect(isZipFunctionInstrumented).toStrictEqual(true);
+    },
+  );
 
   it("correctly tags instrumented functions", async () => {
     const functions = await createFunctions({}, 51);

--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -39,7 +39,8 @@ import {
 } from "./utilities/s3-error-object";
 import config, { region } from "./config.json";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const containerImageFunctionName = (config as any).containerImageFunctionName as string;
+const containerImageFunctionName = (config as any)
+  .containerImageFunctionName as string;
 
 describe("Remote instrumenter scheduled event tests", () => {
   const functionThatDoesntExist = "ThisDoesNotExist";
@@ -519,18 +520,23 @@ describe("Remote instrumenter scheduled event tests", () => {
 
     // The container image function must appear in skipped with unsupported-runtime,
     // not in failed and not in succeeded.
-    expect(Object.keys(res.instrument.skipped)).toContain(containerImageFunctionName);
-    expect(res.instrument.skipped[containerImageFunctionName].reasonCode).toStrictEqual(
-      "unsupported-runtime",
+    expect(Object.keys(res.instrument.skipped)).toContain(
+      containerImageFunctionName,
     );
-    expect(Object.keys(res.instrument.failed)).not.toContain(containerImageFunctionName);
+    expect(
+      res.instrument.skipped[containerImageFunctionName].reasonCode,
+    ).toStrictEqual("unsupported-runtime");
+    expect(Object.keys(res.instrument.failed)).not.toContain(
+      containerImageFunctionName,
+    );
     expect(Object.keys(res.instrument.succeeded)).not.toContain(
       containerImageFunctionName,
     );
 
     // The container image function must remain un-instrumented (no layers, no env vars).
-    const isImageFunctionUninstrumented =
-      await isFunctionUninstrumented(containerImageFunctionName);
+    const isImageFunctionUninstrumented = await isFunctionUninstrumented(
+      containerImageFunctionName,
+    );
     expect(isImageFunctionUninstrumented).toStrictEqual(true);
 
     // The zip-based function in the same batch must still have been instrumented,

--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -38,11 +38,12 @@ import {
   putErrorObject,
   doesErrorObjectExist,
 } from "./utilities/s3-error-object";
-import config from "./config.json";
-const { region } = config;
+import { region } from "./config.json";
 // containerImageUri is optional — add it to config.json during environment setup.
 // Tests that require it are skipped automatically when it's absent.
-const containerImageUri: string | undefined = (config as any).containerImageUri;
+import configJson from "./config.json";
+const containerImageUri: string | undefined = (configJson as any)
+  .containerImageUri;
 
 describe("Remote instrumenter scheduled event tests", () => {
   const functionThatDoesntExist = "ThisDoesNotExist";

--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -38,7 +38,9 @@ import {
   putErrorObject,
   doesErrorObjectExist,
 } from "./utilities/s3-error-object";
-import { region, containerImageUri } from "./config.json";
+import config, { region } from "./config.json";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const containerImageUri = (config as any).containerImageUri as string;
 
 describe("Remote instrumenter scheduled event tests", () => {
   const functionThatDoesntExist = "ThisDoesNotExist";
@@ -503,51 +505,46 @@ describe("Remote instrumenter scheduled event tests", () => {
   // The instrumenter must skip them gracefully rather than crashing the batch:
   // a TypeError in isSupportedRuntime would previously abort the entire scheduled run,
   // leaving all other functions in the account un-instrumented as well.
-  it(
-    "container image Lambda (Runtime: undefined) is skipped without crashing the batch",
-    async () => {
-      await setRemoteConfig();
+  it("container image Lambda (Runtime: undefined) is skipped without crashing the batch", async () => {
+    await setRemoteConfig();
 
-      // Create one zip-based function that should get instrumented
-      const { FunctionName: zipFunctionName } = await createFunction({
+    // Create one zip-based function that should get instrumented
+    const { FunctionName: zipFunctionName } = await createFunction({
+      Tags: { foo: "bar" },
+    });
+
+    // Create a container image function with tags that match the targeting rule.
+    // Its Runtime will be undefined in the Lambda API response.
+    const { FunctionName: imageFunctionName } =
+      await createContainerImageFunction(containerImageUri, {
         Tags: { foo: "bar" },
       });
 
-      // Create a container image function with tags that match the targeting rule.
-      // Its Runtime will be undefined in the Lambda API response.
-      const { FunctionName: imageFunctionName } =
-        await createContainerImageFunction(containerImageUri, {
-          Tags: { foo: "bar" },
-        });
+    const res = await invokeLambdaWithScheduledEvent();
 
-      const res = await invokeLambdaWithScheduledEvent();
+    // The container image function must appear in skipped with unsupported-runtime,
+    // not in failed and not in succeeded.
+    expect(Object.keys(res.instrument.skipped)).toContain(imageFunctionName);
+    expect(res.instrument.skipped[imageFunctionName].reasonCode).toStrictEqual(
+      "unsupported-runtime",
+    );
+    expect(Object.keys(res.instrument.failed)).not.toContain(imageFunctionName);
+    expect(Object.keys(res.instrument.succeeded)).not.toContain(
+      imageFunctionName,
+    );
 
-      // The container image function must appear in skipped with unsupported-runtime,
-      // not in failed and not in succeeded.
-      expect(Object.keys(res.instrument.skipped)).toContain(imageFunctionName);
-      expect(
-        res.instrument.skipped[imageFunctionName].reasonCode,
-      ).toStrictEqual("unsupported-runtime");
-      expect(Object.keys(res.instrument.failed)).not.toContain(
-        imageFunctionName,
-      );
-      expect(Object.keys(res.instrument.succeeded)).not.toContain(
-        imageFunctionName,
-      );
+    // The container image function must remain un-instrumented (no layers, no env vars).
+    const isImageFunctionUninstrumented =
+      await isFunctionUninstrumented(imageFunctionName);
+    expect(isImageFunctionUninstrumented).toStrictEqual(true);
 
-      // The container image function must remain un-instrumented (no layers, no env vars).
-      const isImageFunctionUninstrumented =
-        await isFunctionUninstrumented(imageFunctionName);
-      expect(isImageFunctionUninstrumented).toStrictEqual(true);
-
-      // The zip-based function in the same batch must still have been instrumented,
-      // proving the container image function did not crash the batch.
-      const isZipFunctionInstrumented = await pollUntilTrue(60000, 5000, () =>
-        isFunctionInstrumented(zipFunctionName),
-      );
-      expect(isZipFunctionInstrumented).toStrictEqual(true);
-    },
-  );
+    // The zip-based function in the same batch must still have been instrumented,
+    // proving the container image function did not crash the batch.
+    const isZipFunctionInstrumented = await pollUntilTrue(60000, 5000, () =>
+      isFunctionInstrumented(zipFunctionName),
+    );
+    expect(isZipFunctionInstrumented).toStrictEqual(true);
+  });
 
   it("correctly tags instrumented functions", async () => {
     const functions = await createFunctions({}, 51);

--- a/integration-tests/scheduled-events.test.ts
+++ b/integration-tests/scheduled-events.test.ts
@@ -31,6 +31,7 @@ import {
   deleteTestFunctions,
   createFunctions,
   tagFunction,
+  CONTAINER_IMAGE_URI,
 } from "./utilities/lambda-functions";
 import { Runtime } from "@aws-sdk/client-lambda";
 import {
@@ -39,11 +40,6 @@ import {
   doesErrorObjectExist,
 } from "./utilities/s3-error-object";
 import { region } from "./config.json";
-// containerImageUri is optional — add it to config.json during environment setup.
-// Tests that require it are skipped automatically when it's absent.
-import configJson from "./config.json";
-const containerImageUri: string | undefined = (configJson as any)
-  .containerImageUri;
 
 describe("Remote instrumenter scheduled event tests", () => {
   const functionThatDoesntExist = "ThisDoesNotExist";
@@ -508,51 +504,46 @@ describe("Remote instrumenter scheduled event tests", () => {
   // The instrumenter must skip them gracefully rather than crashing the batch:
   // a TypeError in isSupportedRuntime would previously abort the entire scheduled run,
   // leaving all other functions in the account un-instrumented as well.
-  it.skipIf(!containerImageUri)(
-    "container image Lambda (Runtime: undefined) is skipped without crashing the batch",
-    async () => {
-      await setRemoteConfig();
+  it("container image Lambda (Runtime: undefined) is skipped without crashing the batch", async () => {
+    await setRemoteConfig();
 
-      // Create one zip-based function that should get instrumented
-      const { FunctionName: zipFunctionName } = await createFunction({
+    // Create one zip-based function that should get instrumented
+    const { FunctionName: zipFunctionName } = await createFunction({
+      Tags: { foo: "bar" },
+    });
+
+    // Create a container image function with tags that match the targeting rule.
+    // Its Runtime will be undefined in the Lambda API response.
+    const { FunctionName: imageFunctionName } =
+      await createContainerImageFunction(CONTAINER_IMAGE_URI, {
         Tags: { foo: "bar" },
       });
 
-      // Create a container image function with tags that match the targeting rule.
-      // Its Runtime will be undefined in the Lambda API response.
-      const { FunctionName: imageFunctionName } =
-        await createContainerImageFunction(containerImageUri!, {
-          Tags: { foo: "bar" },
-        });
+    const res = await invokeLambdaWithScheduledEvent();
 
-      const res = await invokeLambdaWithScheduledEvent();
+    // The container image function must appear in skipped with unsupported-runtime,
+    // not in failed and not in succeeded.
+    expect(Object.keys(res.instrument.skipped)).toContain(imageFunctionName);
+    expect(res.instrument.skipped[imageFunctionName].reasonCode).toStrictEqual(
+      "unsupported-runtime",
+    );
+    expect(Object.keys(res.instrument.failed)).not.toContain(imageFunctionName);
+    expect(Object.keys(res.instrument.succeeded)).not.toContain(
+      imageFunctionName,
+    );
 
-      // The container image function must appear in skipped with unsupported-runtime,
-      // not in failed and not in succeeded.
-      expect(Object.keys(res.instrument.skipped)).toContain(imageFunctionName);
-      expect(
-        res.instrument.skipped[imageFunctionName].reasonCode,
-      ).toStrictEqual("unsupported-runtime");
-      expect(Object.keys(res.instrument.failed)).not.toContain(
-        imageFunctionName,
-      );
-      expect(Object.keys(res.instrument.succeeded)).not.toContain(
-        imageFunctionName,
-      );
+    // The container image function must remain un-instrumented (no layers, no env vars).
+    const isImageFunctionUninstrumented =
+      await isFunctionUninstrumented(imageFunctionName);
+    expect(isImageFunctionUninstrumented).toStrictEqual(true);
 
-      // The container image function must remain un-instrumented (no layers, no env vars).
-      const isImageFunctionUninstrumented =
-        await isFunctionUninstrumented(imageFunctionName);
-      expect(isImageFunctionUninstrumented).toStrictEqual(true);
-
-      // The zip-based function in the same batch must still have been instrumented,
-      // proving the container image function did not crash the batch.
-      const isZipFunctionInstrumented = await pollUntilTrue(60000, 5000, () =>
-        isFunctionInstrumented(zipFunctionName),
-      );
-      expect(isZipFunctionInstrumented).toStrictEqual(true);
-    },
-  );
+    // The zip-based function in the same batch must still have been instrumented,
+    // proving the container image function did not crash the batch.
+    const isZipFunctionInstrumented = await pollUntilTrue(60000, 5000, () =>
+      isFunctionInstrumented(zipFunctionName),
+    );
+    expect(isZipFunctionInstrumented).toStrictEqual(true);
+  });
 
   it("correctly tags instrumented functions", async () => {
     const functions = await createFunctions({}, 51);

--- a/integration-tests/test-container/Dockerfile
+++ b/integration-tests/test-container/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/python:3.12
+
+# Minimal handler — only used to verify the instrumenter skips container image
+# functions gracefully; this function is never actually invoked.
+RUN echo 'def handler(event, context): return {}' > /var/task/handler.py
+
+CMD ["handler.handler"]

--- a/integration-tests/utilities/aws-resources.ts
+++ b/integration-tests/utilities/aws-resources.ts
@@ -75,7 +75,8 @@ const getStackOutput = async (outputKey: string): Promise<string> => {
 };
 
 const getEdgeFunctionName = () => getStackOutput("EdgeFunctionName");
-const getContainerImageFunctionName = () => getStackOutput("ContainerImageFunctionName");
+const getContainerImageFunctionName = () =>
+  getStackOutput("ContainerImageFunctionName");
 
 export {
   getSecretsManagerClient,

--- a/integration-tests/utilities/aws-resources.ts
+++ b/integration-tests/utilities/aws-resources.ts
@@ -57,7 +57,7 @@ const getLogsClient = (): any => {
   return logsClient;
 };
 
-const getEdgeFunctionName = async (): Promise<string> => {
+const getStackOutput = async (outputKey: string): Promise<string> => {
   const cfClient = new CloudFormationClient({
     credentials: getCredentials(arn),
     region,
@@ -66,13 +66,16 @@ const getEdgeFunctionName = async (): Promise<string> => {
     new DescribeStacksCommand({ StackName: stackName }),
   );
   const output = result.Stacks?.[0]?.Outputs?.find(
-    (o) => o.OutputKey === "EdgeFunctionName",
+    (o) => o.OutputKey === outputKey,
   );
   if (!output?.OutputValue) {
-    throw new Error(`EdgeFunctionName output not found in stack ${stackName}`);
+    throw new Error(`${outputKey} output not found in stack ${stackName}`);
   }
   return output.OutputValue;
 };
+
+const getEdgeFunctionName = () => getStackOutput("EdgeFunctionName");
+const getContainerImageFunctionName = () => getStackOutput("ContainerImageFunctionName");
 
 export {
   getSecretsManagerClient,
@@ -80,4 +83,5 @@ export {
   getS3Client,
   getLogsClient,
   getEdgeFunctionName,
+  getContainerImageFunctionName,
 };

--- a/integration-tests/utilities/lambda-functions.ts
+++ b/integration-tests/utilities/lambda-functions.ts
@@ -186,7 +186,7 @@ const createContainerImageFunction = async (
     MemorySize: 128,
     Tags: {
       dd_serverless_service: "remote_instrumenter_testing",
-      ...((extraProps.Tags as Record<string, string>) ?? {}),
+      ...(extraProps.Tags as Record<string, string>),
     },
     ...extraProps,
   });

--- a/integration-tests/utilities/lambda-functions.ts
+++ b/integration-tests/utilities/lambda-functions.ts
@@ -14,11 +14,6 @@ import { account, region, namingSeed, testLambdaRole } from "../config.json";
 import { getLambdaClient } from "./aws-resources";
 import { sleep } from "./sleep";
 
-// Public AWS Lambda base image used by container image integration tests.
-// Using a public ECR image ensures tests always run in CI without needing
-// a private ECR repository or dynamically generated config.
-export const CONTAINER_IMAGE_URI = "public.ecr.aws/lambda/python:3.12";
-
 const functionNamesToCleanUp: string[] = [];
 const functionNameCount: Record<string, number> = {};
 

--- a/integration-tests/utilities/lambda-functions.ts
+++ b/integration-tests/utilities/lambda-functions.ts
@@ -167,9 +167,52 @@ const isFunctionInvokable = async (functionName: string): Promise<boolean> => {
   return StatusCode === 200;
 };
 
+// Creates a container image Lambda (PackageType: "Image").
+// These functions have Runtime: undefined in API responses, which is the real-world
+// scenario for functions deployed as container images rather than zip archives.
+// The image must exist in ECR and be accessible to the test account's Lambda role.
+const createContainerImageFunction = async (
+  imageUri: string,
+  extraProps: Record<string, unknown> = {},
+): Promise<any> => {
+  const lambdaClient = await getLambdaClient();
+  const functionName = generateTestFunctionName();
+
+  const command = new CreateFunctionCommand({
+    FunctionName: functionName,
+    Role: `arn:aws:iam::${account}:role/${testLambdaRole}`,
+    PackageType: "Image",
+    Code: { ImageUri: imageUri },
+    MemorySize: 128,
+    Tags: {
+      dd_serverless_service: "remote_instrumenter_testing",
+      ...((extraProps.Tags as Record<string, string>) ?? {}),
+    },
+    ...extraProps,
+  });
+
+  let lambda;
+  try {
+    lambda = await lambdaClient.send(command);
+  } catch (e) {
+    if (e instanceof ResourceConflictException) {
+      await lambdaClient.send(
+        new DeleteFunctionCommand({ FunctionName: functionName }),
+      );
+      lambda = await lambdaClient.send(command);
+    } else {
+      throw e;
+    }
+  }
+
+  functionNamesToCleanUp.push(lambda.FunctionName);
+  return lambda;
+};
+
 export {
   createFunctions,
   createFunction,
+  createContainerImageFunction,
   deleteFunction,
   deleteTestFunctions,
   tagFunction,

--- a/integration-tests/utilities/lambda-functions.ts
+++ b/integration-tests/utilities/lambda-functions.ts
@@ -14,6 +14,11 @@ import { account, region, namingSeed, testLambdaRole } from "../config.json";
 import { getLambdaClient } from "./aws-resources";
 import { sleep } from "./sleep";
 
+// Public AWS Lambda base image used by container image integration tests.
+// Using a public ECR image ensures tests always run in CI without needing
+// a private ECR repository or dynamically generated config.
+export const CONTAINER_IMAGE_URI = "public.ecr.aws/lambda/python:3.12";
+
 const functionNamesToCleanUp: string[] = [];
 const functionNameCount: Record<string, number> = {};
 

--- a/integration-tests/utilities/lambda-functions.ts
+++ b/integration-tests/utilities/lambda-functions.ts
@@ -177,6 +177,7 @@ const createContainerImageFunction = async (
 ): Promise<any> => {
   const lambdaClient = await getLambdaClient();
   const functionName = generateTestFunctionName();
+  const { Tags: extraTags, ...restProps } = extraProps;
 
   const command = new CreateFunctionCommand({
     FunctionName: functionName,
@@ -186,9 +187,9 @@ const createContainerImageFunction = async (
     MemorySize: 128,
     Tags: {
       dd_serverless_service: "remote_instrumenter_testing",
-      ...(extraProps.Tags as Record<string, string>),
+      ...(extraTags as Record<string, string>),
     },
-    ...extraProps,
+    ...restProps,
   });
 
   let lambda;
@@ -206,6 +207,21 @@ const createContainerImageFunction = async (
   }
 
   functionNamesToCleanUp.push(lambda.FunctionName);
+
+  // Wait for the function to leave Pending state before returning
+  let state = "Pending";
+  while (state === "Pending") {
+    const status = await lambdaClient.send(
+      new GetFunctionConfigurationCommand({
+        FunctionName: lambda.FunctionName,
+      }),
+    );
+    state = status.State ?? "Active";
+    if (state === "Pending") {
+      await sleep(1000);
+    }
+  }
+
   return lambda;
 };
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -113,6 +113,10 @@ export const SUPPORTED_RUNTIME_CONFIGURATIONS: Record<
   },
 };
 
+// Returns the runtime configuration for a given runtime string, or undefined if
+// the runtime is unsupported. Container image Lambdas have Runtime: undefined
+// in the AWS API response — the early return ensures they are treated as
+// unsupported rather than causing a TypeError in isSupportedRuntime.
 export const getRuntimeConfig = (
   runtime: string | undefined,
 ): RuntimeConfiguration | undefined => {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -114,11 +114,13 @@ export const SUPPORTED_RUNTIME_CONFIGURATIONS: Record<
 };
 
 export const getRuntimeConfig = (
-  runtime: string,
-): RuntimeConfiguration | undefined =>
-  Object.entries(SUPPORTED_RUNTIME_CONFIGURATIONS).find(([, config]) =>
+  runtime: string | undefined,
+): RuntimeConfiguration | undefined => {
+  if (!runtime) return undefined;
+  return Object.entries(SUPPORTED_RUNTIME_CONFIGURATIONS).find(([, config]) =>
     config.isSupportedRuntime(runtime),
   )?.[1];
+};
 
 // Event Types
 export const LAMBDA_EVENT = "LambdaEvent";

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -1580,6 +1580,49 @@ describe("needsInstrumentationUpdate", () => {
       expect(isTaggedWithCurrentVersion(lambdaFunc)).toBe(false);
     });
   });
+
+  describe("When the function is a container image Lambda (Runtime is undefined)", () => {
+    test("should skip without throwing, not crash the batch", () => {
+      const ruleFilters = [
+        { key: "foo", values: ["bar"], allow: true, filterType: "tag" },
+      ];
+      const lambdaFunc = createTestLambdaFunction({
+        functionName: "containerImageFn",
+        functionArn:
+          "arn:aws:lambda:us-east-1:123456789012:function:containerImageFn",
+        runtime: undefined,
+        tags: new Set(["foo:bar"]),
+        layers: [],
+      });
+      const config = createTestConfig({
+        entityType: "lambda",
+        extensionVersion: 1,
+        nodeLayerVersion: 1,
+        pythonLayerVersion: 1,
+        priority: 1,
+        ruleFilters,
+      });
+      expect(() =>
+        needsInstrumentationUpdate(
+          lambdaFunc,
+          config,
+          baseInstrumentOutcome,
+          false,
+        ),
+      ).not.toThrow();
+      const { instrument, uninstrument, tag, untag } =
+        needsInstrumentationUpdate(
+          lambdaFunc,
+          config,
+          baseInstrumentOutcome,
+          false,
+        );
+      expect(instrument).toBe(false);
+      expect(uninstrument).toBe(false);
+      expect(tag).toBe(false);
+      expect(untag).toBe(false);
+    });
+  });
 });
 
 describe("filterFunctionsToChangeInstrumentation", () => {


### PR DESCRIPTION
## Summary

- \`getRuntimeConfig\` in \`consts.ts\` iterates over all runtime configurations and calls \`isSupportedRuntime(runtime)\` on each — each of which calls \`runtime.toLowerCase()\`
- Container image Lambdas return \`Runtime: undefined\` from the AWS SDK
- This caused a \`TypeError: Cannot read properties of undefined (reading 'toLowerCase')\` that propagated up and **aborted the entire instrumentation batch**, not just the offending function
- Fix: guard \`getRuntimeConfig\` against \`undefined\` so container image functions are treated as unsupported runtime (skipped gracefully)

## Root cause (from customer report)

Phreesia reported 93 functions failing instrumentation with repeated \`TypeError\` at \`isSupportedRuntime\`. Their account included container image Lambdas mixed in with zip-based ones. One undefined runtime crashed the whole EventBridge-triggered batch.

## Test plan

- [x] Unit: \`needsInstrumentationUpdate\` with \`Runtime: undefined\` must not throw and must return all-false (skip)
- [x] Integration (scheduled event): container image Lambda is skipped with \`unsupported-runtime\`, zip-based function in same batch is still instrumented
- [x] Integration (lambda management event): container image Lambda triggers no instrumenter crash, is skipped with \`unsupported-runtime\`, remains un-instrumented
- [x] All 275 existing unit tests pass

Note: integration tests require \`containerImageUri\` in \`integration-tests/config.json\` pointing to a Lambda-compatible ECR image in the test account.